### PR TITLE
Set LORA_CACHE_DIR to persist LoRA downloads on RunPod persistent volume

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -34,6 +34,7 @@ QUEUE_URL=${QUEUE_URL:-http://api.wanly22.com:8001}
 FRIENDLY_NAME=${FRIENDLY_NAME:-runpod-${RUNPOD_POD_ID:-unknown}}
 COMFYUI_URL=http://localhost:8188
 COMFYUI_PATH=/app/ComfyUI
+LORA_CACHE_DIR=/workspace/models/loras
 EOF
 
 echo "Daemon config:"


### PR DESCRIPTION
Points daemon downloads to /workspace/models/loras/ which ComfyUI already searches via extra_model_paths.yaml, so LoRAs survive restarts.