### PR TITLE
Add PainterLongVideo and CLIP vision for RunPod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ RUN git clone --depth 1 https://github.com/Gourieff/ComfyUI-ReActor.git \
     pip install --no-cache-dir -r ComfyUI/custom_nodes/comfyui-reactor-node/requirements.txt && \
     pip install --no-cache-dir onnxruntime-gpu
 
+# Custom nodes: PainterLongVideo (identity anchoring for chained segments)
+RUN git clone --depth 1 https://github.com/princepainter/ComfyUI-PainterLongVideo.git \
+    ComfyUI/custom_nodes/ComfyUI-PainterLongVideo
+
 # Daemon Python dependencies (daemon code itself is cloned at boot for freshness)
 RUN pip install --no-cache-dir httpx pydantic-settings python-dotenv websockets
 

--- a/download_models.sh
+++ b/download_models.sh
@@ -11,6 +11,7 @@ mkdir -p "${MODELS_DIR}/clip"
 mkdir -p "${MODELS_DIR}/vae"
 mkdir -p "${MODELS_DIR}/diffusion_models"
 mkdir -p "${MODELS_DIR}/loras"
+mkdir -p "${MODELS_DIR}/clip_vision"
 
 download() {
     local url="$1"
@@ -59,6 +60,10 @@ download "${HF_BASE}/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safeten
 
 download "${HF_BASE}/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors" \
     "${MODELS_DIR}/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors"
+
+# CLIP Vision model for PainterLongVideo identity anchoring (~3.9 GB)
+download "https://huggingface.co/h94/IP-Adapter/resolve/main/models/image_encoder/model.safetensors" \
+    "${MODELS_DIR}/clip_vision/clip_vision_h.safetensors"
 
 # ReActor face swap model — goes into ComfyUI/models/insightface (not persistent volume)
 INSIGHTFACE_DIR="/app/ComfyUI/models/insightface"

--- a/extra_model_paths.yaml
+++ b/extra_model_paths.yaml
@@ -4,3 +4,4 @@ wanly:
     vae: vae/
     diffusion_models: diffusion_models/
     loras: loras/
+    clip_vision: clip_vision/


### PR DESCRIPTION
## Summary
- **Dockerfile**: installs `ComfyUI-PainterLongVideo` custom node
- **download_models.sh**: downloads `clip_vision_h.safetensors` (~3.9 GB) for CLIP vision encoding
- **extra_model_paths.yaml**: adds `clip_vision` path mapping so ComfyUI finds the model

Required for PainterLongVideo identity anchoring on chained segments (prevents character drift).

## Test plan
- [ ] Build Docker image — verify PainterLongVideo is in custom_nodes
- [ ] Run on RunPod — verify clip_vision_h.safetensors downloads
- [ ] Run multi-segment job — verify PainterLongVideo executes with CLIP vision

🤖 Generated with [Claude Code](https://claude.com/claude-code)