### PR TITLE
Add --cache-none to ComfyUI startup

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -46,6 +46,7 @@ cd /app/ComfyUI
 python3 main.py --listen 0.0.0.0 --port 8188 \
     --extra-model-paths-config extra_model_paths.yaml \
     --preview-method latent2rgb \
+    --cache-none \
     > /workspace/logs/comfyui.log 2>&1 &
 COMFYUI_PID=$!
 echo "ComfyUI started (PID $COMFYUI_PID)"


### PR DESCRIPTION
## Summary
- Adds `--cache-none` flag to ComfyUI startup in `start.sh`
- Prevents both 14B fp16 UNETs from being cached in VRAM simultaneously
- Drops idle VRAM from ~21GB to ~9.5GB, leaving ~15GB for generation

## Context
RunPod 3090s were failing all jobs with "RIFE VFI requires at least 2 frames" because the Wan model silently produced only 1 frame due to VRAM exhaustion. Local 3090 worked fine because it already had `--cache-none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)