### PR TITLE
Disable ReActor NSFW filter on startup

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -40,6 +40,15 @@ EOF
 echo "Daemon config:"
 cat "$DAEMON_DIR/.env"
 
+# ---------- 3b. Disable ReActor NSFW filter ----------
+# ReActor's hardcoded NSFW filter drops video frames it considers unsafe,
+# which breaks RIFE (needs >= 2 frames). Set threshold to 1.0 to disable.
+REACTOR_SFW="/app/ComfyUI/custom_nodes/comfyui-reactor-node/scripts/reactor_sfw.py"
+if [ -f "$REACTOR_SFW" ]; then
+    sed -i 's/^SCORE = .*/SCORE = 1.0/' "$REACTOR_SFW"
+    echo "Patched ReActor NSFW threshold to 1.0 (disabled)"
+fi
+
 # ---------- 4. Start ComfyUI (background, no auth) ----------
 mkdir -p /workspace/logs
 cd /app/ComfyUI


### PR DESCRIPTION
## Summary
- Patch ReActor's NSFW score threshold to 1.0 on container startup
- ReActor was detecting AI-generated video frames as NSFW (score 0.999) and dropping them
- This left downstream RIFE interpolation with < 2 frames, causing crashes

## Test plan
- [ ] Verify NSFW threshold is patched after container start
- [ ] Create job with faceswap — all frames should be processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)