### PR TITLE
Drop --lowvram flag from ComfyUI

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -59,7 +59,7 @@ cd /app/ComfyUI
 python3 main.py --listen 0.0.0.0 --port 8188 \
     --extra-model-paths-config extra_model_paths.yaml \
     --preview-method latent2rgb \
-    --cache-none --lowvram \
+    --cache-none \
     > /workspace/logs/comfyui.log 2>&1 &
 COMFYUI_PID=$!
 echo "ComfyUI started (PID $COMFYUI_PID)"


### PR DESCRIPTION
## Summary
- Remove `--lowvram` flag from ComfyUI startup in `start.sh`
- 3090 Ti has 24GB VRAM (same as local 3090 which runs fine without it)
- The flag was offloading ~9.6GB to CPU unnecessarily and may contribute to blurry faceswap output (#63)

## Test plan
- [ ] Rebuild Docker image and deploy to RunPod
- [ ] Verify ComfyUI starts without OOM on 3090 Ti
- [ ] Run a faceswap job and compare quality to previous output

🤖 Generated with [Claude Code](https://claude.com/claude-code)