### PR TITLE
fix: stub ReActor transformers import to survive torch<2.7 skew

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -47,10 +47,19 @@ cat "$DAEMON_DIR/.env"
 # ReActor's hardcoded NSFW filter drops video frames it considers unsafe,
 # which breaks RIFE (needs >= 2 frames). Inject early return into nsfw_image()
 # so the NSFW model never loads or runs (same approach as local 3090).
+#
+# We also neutralize reactor_sfw.py's top-level `from transformers import pipeline`.
+# ReActor's requirements.txt is unpinned and now pulls transformers >= 5.x, which
+# references torch.float8_e8m0fnu (torch >= 2.7) at import time. This image pins
+# torch 2.6.0, so that import raises AttributeError, the whole reactor node fails
+# to register, and ComfyUI rejects any workflow using ReActorOptions with a 400.
+# `pipeline` is only used inside nsfw_image(), which we disable above, so the import
+# is dead weight — replacing it with a stub sidesteps the version skew entirely.
 REACTOR_SFW="/app/ComfyUI/custom_nodes/comfyui-reactor-node/scripts/reactor_sfw.py"
 if [ -f "$REACTOR_SFW" ]; then
     sed -i '/^def nsfw_image/a\    return False  # NSFW filter disabled by wanly start.sh' "$REACTOR_SFW"
-    echo "Patched ReActor: nsfw_image() returns False (disabled)"
+    sed -i '1s|^from transformers import pipeline.*|pipeline = None  # transformers import disabled by wanly (torch<2.7 incompat)|' "$REACTOR_SFW"
+    echo "Patched ReActor: nsfw_image() returns False (disabled), transformers import stubbed"
 fi
 
 # ---------- 4. Start ComfyUI (background, no auth) ----------


### PR DESCRIPTION
## Problem

A freshly-built RunPod worker crashes the ReActor custom node on startup, so ComfyUI rejects every workflow using `ReActorOptions` with a 400:

```
ERROR ComfyUI rejected workflow (400): {"type": "missing_node_type",
  "message": "Node 'ReActor Options' not found. The custom node may not be installed.",
  "class_type": "ReActorOptions"}
```

## Root cause

The node package *is* installed — it fails to **import**. Traceback from `/workspace/logs/comfyui.log`:

```
reactor_sfw.py line 1:  from transformers import pipeline
  ...
transformers/integrations/finegrained_fp8.py line 45:
    _UE8M0_SF_DTYPE = torch.float8_e8m0fnu
AttributeError: module 'torch' has no attribute 'float8_e8m0fnu'
```

- ReActor's `requirements.txt` is unpinned and now pulls **transformers 5.10.2**.
- transformers 5.x references `torch.float8_e8m0fnu`, which only exists in **torch >= 2.7**.
- This image pins **torch 2.6.0+cu124**, so the import raises, ReActor never registers, and the daemon's `node_checker` can't help (the directory exists, so it only logs a warning).

`pipeline` is used *only* inside `nsfw_image()` — which `start.sh` already short-circuits with `return False`. So the import is dead weight.

## Fix

Extend the existing `reactor_sfw.py` patch block in `start.sh` to also stub the top-level `transformers` import. Version-proof — no transformers/torch pin to maintain, and consistent with the NSFW-disable approach already in place.

## Verification

Applied the same edit live on the running pod (`pr0mv0dyr53lvz`), restarted ComfyUI:
- ReActor imports cleanly (`0.6 seconds`, no `IMPORT FAILED`)
- `/object_info` reports `ReActorOptions present: True` (687 nodes)

Requires an image rebuild to take effect on new/restarted pods.