### PR TITLE
Harden download_models.sh: no hub downgrade + ReActor repo_type + non-fatal aux

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -16,9 +16,11 @@ INSIGHTFACE_DIR="/app/ComfyUI/models/insightface"
 mkdir -p "${MODELS_DIR}/clip" "${MODELS_DIR}/vae" "${MODELS_DIR}/diffusion_models" \
          "${MODELS_DIR}/loras" "${MODELS_DIR}/clip_vision" "${INSIGHTFACE_DIR}"
 
-# Xet support, pinned <1.0: huggingface_hub 1.x renames the CLI and trips transformers'
-# `huggingface-hub<1.0` pin used by ComfyUI custom nodes (e.g. ReActor) on this image.
-pip install --no-cache-dir -q "huggingface_hub>=0.34,<1.0" hf_xet || true
+# Xet support. Install hf_xet and ensure huggingface_hub is recent enough for Xet,
+# but DON'T cap the version: this image ships transformers 5.x which requires
+# huggingface-hub>=1.5.0, so an upper bound would downgrade it and break the resolver.
+# No bound = pip keeps the image's existing (Xet-capable) hub and just adds hf_xet.
+pip install --no-cache-dir -q "huggingface_hub>=0.34" hf_xet || true
 
 echo "=== Downloading models to ${MODELS_DIR} ==="
 


### PR DESCRIPTION
Follow-up to #14, two boot-reliability fixes:

**1. Don't downgrade huggingface_hub.** The `<1.0` cap (carried from the training env) downgraded hub to 0.36.2 and tripped pip's resolver — this image ships transformers 5.x which needs `hub>=1.5.0`. Drop the upper bound; keep the image's Xet-capable 1.x hub and just add `hf_xet`.

**2. Fix ReActor + make auxiliary models non-fatal.** `inswapper_128.onnx` lives in a **dataset** repo (`datasets/Gourieff/ReActor`); querying it as a model 401'd, and with `start.sh`'s `set -e` that aborted the whole boot — even though every core Wan model (umt5, VAE, both 14B experts, lightx2v) had already downloaded. Added a `repo_type` per job, and marked `clip_vision` + `inswapper` **non-critical** (warn + continue) so a gated/moved auxiliary repo can never brick the pod boot. Core Wan models stay critical (hard fail).

Validated on the live pod: all core models pulled clean via the HF downloader (the VAE that 403'd under aria2 now succeeds); only the mis-typed ReActor entry failed, which this fixes.