### PR TITLE
Boot RunPod workers on 3090 parity (DaSiWa + validated config)

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -41,10 +41,8 @@ JOBS = [
           f"{M}/clip/umt5_xxl_fp8_e4m3fn_scaled.safetensors", "model", True),
     (WAN, "split_files/vae/wan_2.1_vae.safetensors",
           f"{M}/vae/wan_2.1_vae.safetensors", "model", True),
-    (WAN, "split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp16.safetensors",
-          f"{M}/diffusion_models/wan2.2_i2v_high_noise_14B_fp16.safetensors", "model", True),
-    (WAN, "split_files/diffusion_models/wan2.2_i2v_low_noise_14B_fp16.safetensors",
-          f"{M}/diffusion_models/wan2.2_i2v_low_noise_14B_fp16.safetensors", "model", True),
+    # NOTE: base Wan 2.2 diffusion models are NOT downloaded — the validated pipeline uses
+    # the DaSiWa "Lightspeed" remix (fetched from Civitai below), matching the 3090.
     (WAN, "split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors",
           f"{M}/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors", "model", True),
     (WAN, "split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors",
@@ -85,5 +83,32 @@ for repo, path, dst, repo_type, critical in JOBS:
     finally:
         shutil.rmtree(stage, ignore_errors=True)
 
-print("=== Model download complete ===")
+print("=== HF model download complete ===")
 PY
+
+# --- DaSiWa "Lightspeed" remix (Civitai) — the VALIDATED inference model (matches 3090) ---
+# These are gated downloads (HTTP 401 without auth), so a Civitai API token is required.
+# Set CIVITAI_TOKEN as a pod env var at launch. The Lightspeed distillation is baked into
+# this model, which is why the validated config runs LIGHTX2V_STRENGTH_* = 0 (see start.sh).
+DASIWA_HIGH_URL="https://civitai.red/api/download/models/2953474?fileId=2837908"
+DASIWA_LOW_URL="https://civitai.red/api/download/models/2953485?fileId=2837910"
+
+dl_civitai() {  # url  dest
+    local url="$1" dst="$2" name; name="$(basename "$dst")"
+    if [ -f "$dst" ] && [ "$(stat -c%s "$dst" 2>/dev/null || echo 0)" -gt 1000000 ]; then
+        echo "SKIP ${name} (already exists)"; return 0
+    fi
+    if [ -z "${CIVITAI_TOKEN:-}" ]; then
+        echo "ERROR: CIVITAI_TOKEN not set — cannot download DaSiWa model ${name}" >&2
+        return 1
+    fi
+    echo "DOWNLOADING ${name} (Civitai)"
+    curl -fL --retry 3 --retry-delay 5 -H "Authorization: Bearer ${CIVITAI_TOKEN}" \
+        -o "${dst}.part" "$url" && mv -f "${dst}.part" "$dst"
+    echo "OK ${name} ($(( $(stat -c%s "$dst") / 1000000 )) MB)"
+}
+
+dl_civitai "$DASIWA_HIGH_URL" "${MODELS_DIR}/diffusion_models/DasiwaWAN22I2V14BLightspeed_snatchkissHighV11.safetensors"
+dl_civitai "$DASIWA_LOW_URL"  "${MODELS_DIR}/diffusion_models/DasiwaWAN22I2V14BLightspeed_snatchkissLowV11.safetensors"
+
+echo "=== Model download complete ==="

--- a/start.sh
+++ b/start.sh
@@ -39,14 +39,25 @@ fi
 pip install --no-cache-dir -q -r "$DAEMON_DIR/requirements.txt" 2>/dev/null || true
 
 # ---------- 3. Write daemon .env ----------
+# Generation config defaults = the 3090's VALIDATED pipeline (source of truth), so a fresh
+# worker boots on parity. DaSiWa "Lightspeed" remix with the distillation baked in -> external
+# lightx2v OFF (strength 0). All overridable via pod env vars if needed.
 cat > "$DAEMON_DIR/.env" << EOF
 QUEUE_URL=${QUEUE_URL:-http://api.wanly22.com:8001}
 FRIENDLY_NAME=${FRIENDLY_NAME:-runpod-${RUNPOD_POD_ID:-unknown}}
 COMFYUI_URL=http://localhost:8188
 COMFYUI_PATH=/app/ComfyUI
 LORA_CACHE_DIR=/workspace/models/loras
-LIGHTX2V_STRENGTH_HIGH=${LIGHTX2V_STRENGTH_HIGH:-2.0}
-LIGHTX2V_STRENGTH_LOW=${LIGHTX2V_STRENGTH_LOW:-1.0}
+UNET_HIGH_MODEL=${UNET_HIGH_MODEL:-DasiwaWAN22I2V14BLightspeed_snatchkissHighV11.safetensors}
+UNET_LOW_MODEL=${UNET_LOW_MODEL:-DasiwaWAN22I2V14BLightspeed_snatchkissLowV11.safetensors}
+LIGHTX2V_STRENGTH_HIGH=${LIGHTX2V_STRENGTH_HIGH:-0.0}
+LIGHTX2V_STRENGTH_LOW=${LIGHTX2V_STRENGTH_LOW:-0.0}
+PAINTER_MOTION_AMPLITUDE=${PAINTER_MOTION_AMPLITUDE:-1.4}
+PAINTER_MOTION_FRAMES=${PAINTER_MOTION_FRAMES:-6}
+UNET_WEIGHT_DTYPE=${UNET_WEIGHT_DTYPE:-fp8_e4m3fn}
+HIGH_NOISE_REALISM=${HIGH_NOISE_REALISM:-false}
+STEPS_TOTAL=${STEPS_TOTAL:-4}
+HIGH_NOISE_STEPS=${HIGH_NOISE_STEPS:-2}
 RUNPOD_API_KEY=${RUNPOD_API_KEY:-}
 QUEUE_API_KEY=${QUEUE_API_KEY:-}
 EOF


### PR DESCRIPTION
## Why
RunPod workers diverged from the 3090 source-of-truth — base Wan + lightx2v 2.0 vs the validated DaSiWa 'Lightspeed' remix (distillation baked in → external lightx2v OFF). That caused the slow-mo and invalidated a day of LoRA tests.

## Changes
- **download_models.sh**: drop base Wan diffusion; fetch **DaSiWa High/Low** (~14.5GB each) from Civitai via `CIVITAI_TOKEN` (Bearer auth), saved as the exact config names.
- **start.sh**: default daemon `.env` to the validated config — DaSiWa models, **lightx2v 0/0**, painter 1.4/6, fp8, steps 4/2 — all env-overridable.

## Verified
Authenticated range request returns 206 + `content-disposition: Dasiwa...HighV11/LowV11.safetensors` (14,528,782,272 bytes each). 

## Op note
Workers must set **`CIVITAI_TOKEN`** as a pod env var (like QUEUE_API_KEY). The stale `REGISTRY_URL` template env var should be removed (dead since the registry merge).