### PR TITLE
runpod: base Wan 2.2 i2v parity with the 3090

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -41,8 +41,13 @@ JOBS = [
           f"{M}/clip/umt5_xxl_fp8_e4m3fn_scaled.safetensors", "model", True),
     (WAN, "split_files/vae/wan_2.1_vae.safetensors",
           f"{M}/vae/wan_2.1_vae.safetensors", "model", True),
-    # NOTE: base Wan 2.2 diffusion models are NOT downloaded — the validated pipeline uses
-    # the DaSiWa "Lightspeed" remix (fetched from Civitai below), matching the 3090.
+    # Base Wan 2.2 i2v diffusion models (high+low) — matches the 3090's current base config.
+    # fp16 files (~28GB each), loaded as fp8 via UNET_WEIGHT_DTYPE. DaSiWa remix is still
+    # fetched below too, so the worker can run either model via the UNET_*_MODEL env vars.
+    (WAN, "split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp16.safetensors",
+          f"{M}/diffusion_models/wan2.2_i2v_high_noise_14B_fp16.safetensors", "model", True),
+    (WAN, "split_files/diffusion_models/wan2.2_i2v_low_noise_14B_fp16.safetensors",
+          f"{M}/diffusion_models/wan2.2_i2v_low_noise_14B_fp16.safetensors", "model", True),
     (WAN, "split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors",
           f"{M}/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors", "model", True),
     (WAN, "split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors",

--- a/start.sh
+++ b/start.sh
@@ -39,25 +39,28 @@ fi
 pip install --no-cache-dir -q -r "$DAEMON_DIR/requirements.txt" 2>/dev/null || true
 
 # ---------- 3. Write daemon .env ----------
-# Generation config defaults = the 3090's VALIDATED pipeline (source of truth), so a fresh
-# worker boots on parity. DaSiWa "Lightspeed" remix with the distillation baked in -> external
-# lightx2v OFF (strength 0). All overridable via pod env vars if needed.
+# Generation config defaults = the 3090's CURRENT base-model config (source of truth), so a
+# fresh worker boots on parity: base Wan 2.2 i2v (fp16 loaded as fp8), 10 steps (5 high / 5 low),
+# cfg 1. lightx2v/cfg are typically overridden per-job from the Wanly UI. DaSiWa remix is still
+# downloaded too — switch to it via UNET_*_MODEL + STEPS_TOTAL=4 pod env vars if needed.
 cat > "$DAEMON_DIR/.env" << EOF
 QUEUE_URL=${QUEUE_URL:-http://api.wanly22.com:8001}
 FRIENDLY_NAME=${FRIENDLY_NAME:-runpod-${RUNPOD_POD_ID:-unknown}}
 COMFYUI_URL=http://localhost:8188
 COMFYUI_PATH=/app/ComfyUI
 LORA_CACHE_DIR=/workspace/models/loras
-UNET_HIGH_MODEL=${UNET_HIGH_MODEL:-DasiwaWAN22I2V14BLightspeed_snatchkissHighV11.safetensors}
-UNET_LOW_MODEL=${UNET_LOW_MODEL:-DasiwaWAN22I2V14BLightspeed_snatchkissLowV11.safetensors}
+UNET_HIGH_MODEL=${UNET_HIGH_MODEL:-wan2.2_i2v_high_noise_14B_fp16.safetensors}
+UNET_LOW_MODEL=${UNET_LOW_MODEL:-wan2.2_i2v_low_noise_14B_fp16.safetensors}
 LIGHTX2V_STRENGTH_HIGH=${LIGHTX2V_STRENGTH_HIGH:-0.0}
 LIGHTX2V_STRENGTH_LOW=${LIGHTX2V_STRENGTH_LOW:-0.0}
 PAINTER_MOTION_AMPLITUDE=${PAINTER_MOTION_AMPLITUDE:-1.4}
 PAINTER_MOTION_FRAMES=${PAINTER_MOTION_FRAMES:-6}
 UNET_WEIGHT_DTYPE=${UNET_WEIGHT_DTYPE:-fp8_e4m3fn}
 HIGH_NOISE_REALISM=${HIGH_NOISE_REALISM:-false}
-STEPS_TOTAL=${STEPS_TOTAL:-4}
-HIGH_NOISE_STEPS=${HIGH_NOISE_STEPS:-2}
+CFG_HIGH=${CFG_HIGH:-1.0}
+CFG_LOW=${CFG_LOW:-1.0}
+STEPS_TOTAL=${STEPS_TOTAL:-10}
+HIGH_NOISE_STEPS=${HIGH_NOISE_STEPS:-5}
 RUNPOD_API_KEY=${RUNPOD_API_KEY:-}
 QUEUE_API_KEY=${QUEUE_API_KEY:-}
 EOF


### PR DESCRIPTION
Switches RunPod defaults from DaSiWa to base Wan 2.2 i2v so a beefier-GPU deploy runs the same job that's slow (offloading) on the 3090.

- `download_models.sh`: pulls base i2v high+low fp16 diffusion models (DaSiWa still fetched too — switchable via `UNET_*_MODEL`)
- `start.sh` defaults: base models, STEPS_TOTAL=10 (5/5), CFG_HIGH/LOW=1.0

**Deploy notes:** base fp16 models are ~28GB each → use a ~120GB volume. lightx2v/cfg are overridden per-job from the Wanly UI. Make sure k3lly2026 (kohya) is registered in the Wanly LoRA repo so the worker fetches it.