### PR TITLE
feat: bake CFG-aware ComfyUI memory patch into RunPod image (24GB/4090 parity)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ RUN git clone https://github.com/comfyanonymous/ComfyUI.git && \
     cd ComfyUI && git checkout ${COMFYUI_COMMIT}
 RUN pip install --no-cache-dir -r ComfyUI/requirements.txt
 
+# Apply the wanly CFG-aware VRAM-estimate patch to ComfyUI (dynamic /tmp/wanly_estimate;
+# prevents over-reserve slow/OOM on 24GB cards and lets de-distilled/CFG>1 jobs fit).
+COPY patch_comfyui_memory.py /app/patch_comfyui_memory.py
+RUN python3 /app/patch_comfyui_memory.py /app/ComfyUI/comfy/model_base.py
+
 # Custom node commits — PINNED so a rebuild can never pull a drifted version (the root
 # cause of repeated boot breakage: unpinned clones pulled newer deps that broke import).
 ARG FRAME_INTERP_COMMIT=26545cc2dd95bc3d27f056016300673bdeee78f5

--- a/patch_comfyui_memory.py
+++ b/patch_comfyui_memory.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Apply the wanly CFG-aware VRAM-estimate patch to ComfyUI's model_base.py.
+Replaces the hardcoded 0.01 activation-memory coefficient with a per-run value read from
+/tmp/wanly_estimate (the daemon writes 0.015 for CFG>1 / de-distilled, 0.003 for distilled).
+This is what prevents over-reserve slow/OOM on 24GB cards and makes de-distilled jobs fit.
+Idempotent; fails loud if the anchor line isn't found (ComfyUI version drift)."""
+import sys, pathlib
+p = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "/app/ComfyUI/comfy/model_base.py")
+s = p.read_text()
+if "_wanly_e" in s:
+    print("model_base.py already patched — skipping"); sys.exit(0)
+stock = "            return (area * comfy.model_management.dtype_size(dtype) * 0.01 * self.memory_usage_factor) * (1024 * 1024)"
+patched = (
+    '            try:\n'
+    '                _wanly_e = float(open("/tmp/wanly_estimate").read().strip())\n'
+    '            except Exception:\n'
+    '                _wanly_e = 0.003\n'
+    "            return (area * comfy.model_management.dtype_size(dtype) * _wanly_e * self.memory_usage_factor) * (1024 * 1024)"
+)
+if stock not in s:
+    print("ERROR: anchor line not found — ComfyUI model_base.py changed; patch needs review", file=sys.stderr)
+    sys.exit(1)
+p.write_text(s.replace(stock, patched, 1))
+print("model_base.py patched: 0.01 -> /tmp/wanly_estimate (cfg-aware VRAM estimate)")


### PR DESCRIPTION
RunPod ran **stock** ComfyUI (hardcoded 0.01 activation-memory coefficient) while the 3090 has the wanly patch reading /tmp/wanly_estimate. On a 24GB 4090 that means over-reserve slow/OOM on base i2v and OOM on the de-distilled/CFG>1 motion recipe. This bakes the same patch into model_base.py at build (idempotent, fails-loud on ComfyUI drift). Daemon already writes the estimate per-run. Enables 4090 test parity with the 3090.