### PR TITLE
feat: VACE continuation support (nodes + models) on RunPod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ RUN git clone https://github.com/comfyanonymous/ComfyUI.git && \
     cd ComfyUI && git checkout ${COMFYUI_COMMIT}
 RUN pip install --no-cache-dir -r ComfyUI/requirements.txt
 
+# Apply the wanly CFG-aware VRAM-estimate patch to ComfyUI (dynamic /tmp/wanly_estimate;
+# prevents over-reserve slow/OOM on 24GB cards and lets de-distilled/CFG>1 jobs fit).
+COPY patch_comfyui_memory.py /app/patch_comfyui_memory.py
+RUN python3 /app/patch_comfyui_memory.py /app/ComfyUI/comfy/model_base.py
+
 # Custom node commits — PINNED so a rebuild can never pull a drifted version (the root
 # cause of repeated boot breakage: unpinned clones pulled newer deps that broke import).
 ARG FRAME_INTERP_COMMIT=26545cc2dd95bc3d27f056016300673bdeee78f5

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,10 @@ ARG FRAME_INTERP_COMMIT=26545cc2dd95bc3d27f056016300673bdeee78f5
 ARG VHS_COMMIT=4ee72c065db22c9d96c2427954dc69e7b908444b
 ARG REACTOR_COMMIT=6ad6b35a4df250d14cb2abf0808c9ffedf59f747
 ARG PAINTER_COMMIT=889b4ff67909561e52d6ae023f5b9e8c33fdba94
+# WanVideoWrapper (KJ) — provides the VACE nodes (WanVideoVACEEncode/Sampler/...).
+# Pinned to 1.3.9 (e926f7a0), the same 1.3.x minor the 3090 runs (its pyproject reports 1.3.3;
+# there is no matching git tag, and VACE node inputs are stable across 1.3.x).
+ARG WANVIDEO_COMMIT=e926f7a069e3efc25bdcc78e1bf65c39ac1a2cd4
 
 # Custom nodes: Frame Interpolation (RIFE)
 # Install cupy-cuda12x directly (pre-built wheel) — the requirements file's cupy-wheel
@@ -72,6 +76,13 @@ RUN git clone https://github.com/Gourieff/ComfyUI-ReActor.git \
 RUN git clone https://github.com/princepainter/ComfyUI-PainterLongVideo.git \
     ComfyUI/custom_nodes/ComfyUI-PainterLongVideo && \
     git -C ComfyUI/custom_nodes/ComfyUI-PainterLongVideo checkout ${PAINTER_COMMIT}
+
+# Custom nodes: WanVideoWrapper (KJ) — the VACE continuation path (nodes 5xx).
+# Directory name matches the daemon's node_checker expectation.
+RUN git clone https://github.com/kijai/ComfyUI-WanVideoWrapper.git \
+    ComfyUI/custom_nodes/ComfyUI-WanVideoWrapper && \
+    git -C ComfyUI/custom_nodes/ComfyUI-WanVideoWrapper checkout ${WANVIDEO_COMMIT} && \
+    pip install --no-cache-dir -r ComfyUI/custom_nodes/ComfyUI-WanVideoWrapper/requirements.txt
 
 # Daemon Python dependencies (daemon code itself is cloned at boot for freshness)
 RUN pip install --no-cache-dir httpx pydantic-settings python-dotenv websockets

--- a/download_models.sh
+++ b/download_models.sh
@@ -14,7 +14,8 @@ MODELS_DIR="/workspace/models"
 INSIGHTFACE_DIR="/app/ComfyUI/models/insightface"
 
 mkdir -p "${MODELS_DIR}/clip" "${MODELS_DIR}/vae" "${MODELS_DIR}/diffusion_models" \
-         "${MODELS_DIR}/loras" "${MODELS_DIR}/clip_vision" "${INSIGHTFACE_DIR}"
+         "${MODELS_DIR}/loras" "${MODELS_DIR}/clip_vision" "${MODELS_DIR}/text_encoders" \
+         "${INSIGHTFACE_DIR}"
 
 # Xet support. Install hf_xet and ensure huggingface_hub is recent enough for Xet,
 # but DON'T cap the version: this image ships transformers 5.x which requires
@@ -53,6 +54,29 @@ JOBS = [
           f"{M}/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors", "model", True),
     (WAN, "split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors",
           f"{M}/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors", "model", True),
+    # === VACE continuation stack (identity-anchored multi-segment) ===
+    # Local filenames MUST match the daemon config's vace_* settings (single source of truth), even
+    # where the HF path differs. Critical: with the WanVideoWrapper nodes installed, the daemon
+    # routes continuations to VACE, so a booted pod must have these or VACE segments fail at load.
+    # T2V base (fp16, ~28GB each) — same weights the 3090 uses; block-swap keeps it on 24GB.
+    (WAN, "split_files/diffusion_models/wan2.2_t2v_high_noise_14B_fp16.safetensors",
+          f"{M}/diffusion_models/wan2.2_t2v_high_noise_14B_fp16.safetensors", "model", True),
+    (WAN, "split_files/diffusion_models/wan2.2_t2v_low_noise_14B_fp16.safetensors",
+          f"{M}/diffusion_models/wan2.2_t2v_low_noise_14B_fp16.safetensors", "model", True),
+    # Fun-VACE modules (fp8, ~3GB each) — Kijai's VACE/ subfolder.
+    ("Kijai/WanVideo_comfy_fp8_scaled", "VACE/Wan2_2_Fun_VACE_module_A14B_HIGH_fp8_e4m3fn_scaled_KJ.safetensors",
+          f"{M}/diffusion_models/Wan2_2_Fun_VACE_module_A14B_HIGH_fp8_e4m3fn_scaled_KJ.safetensors", "model", True),
+    ("Kijai/WanVideo_comfy_fp8_scaled", "VACE/Wan2_2_Fun_VACE_module_A14B_LOW_fp8_e4m3fn_scaled_KJ.safetensors",
+          f"{M}/diffusion_models/Wan2_2_Fun_VACE_module_A14B_LOW_fp8_e4m3fn_scaled_KJ.safetensors", "model", True),
+    # T2V 4-step Lightning distill LoRAs (lightx2v repo names them high/low_noise_model.safetensors;
+    # saved under the daemon's expected names). Rank-64 Seko V1.1.
+    ("lightx2v/Wan2.2-Lightning", "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1/high_noise_model.safetensors",
+          f"{M}/loras/Wan2.2-Lightning_T2V-A14B-4steps-lora_HIGH_fp16.safetensors", "model", True),
+    ("lightx2v/Wan2.2-Lightning", "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1/low_noise_model.safetensors",
+          f"{M}/loras/Wan2.2-Lightning_T2V-A14B-4steps-lora_LOW_fp16.safetensors", "model", True),
+    # umt5-xxl text encoder, bf16 .pth (~11GB) — native Wan-AI name/path (Kijai ships a renamed .safetensors).
+    ("Wan-AI/Wan2.1-T2V-14B", "models_t5_umt5-xxl-enc-bf16.pth",
+          f"{M}/text_encoders/models_t5_umt5-xxl-enc-bf16.pth", "model", True),
     # CLIP Vision (PainterLongVideo identity anchoring) -- auxiliary
     ("h94/IP-Adapter", "models/image_encoder/model.safetensors",
           f"{M}/clip_vision/clip_vision_h.safetensors", "model", False),

--- a/extra_model_paths.yaml
+++ b/extra_model_paths.yaml
@@ -5,3 +5,4 @@ wanly:
     diffusion_models: diffusion_models/
     loras: loras/
     clip_vision: clip_vision/
+    text_encoders: text_encoders/

--- a/patch_comfyui_memory.py
+++ b/patch_comfyui_memory.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Apply the wanly CFG-aware VRAM-estimate patch to ComfyUI's model_base.py.
+Replaces the hardcoded 0.01 activation-memory coefficient with a per-run value read from
+/tmp/wanly_estimate (the daemon writes 0.015 for CFG>1 / de-distilled, 0.003 for distilled).
+This is what prevents over-reserve slow/OOM on 24GB cards and makes de-distilled jobs fit.
+Idempotent; fails loud if the anchor line isn't found (ComfyUI version drift)."""
+import sys, pathlib
+p = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "/app/ComfyUI/comfy/model_base.py")
+s = p.read_text()
+if "_wanly_e" in s:
+    print("model_base.py already patched — skipping"); sys.exit(0)
+stock = "            return (area * comfy.model_management.dtype_size(dtype) * 0.01 * self.memory_usage_factor) * (1024 * 1024)"
+patched = (
+    '            try:\n'
+    '                _wanly_e = float(open("/tmp/wanly_estimate").read().strip())\n'
+    '            except Exception:\n'
+    '                _wanly_e = 0.003\n'
+    "            return (area * comfy.model_management.dtype_size(dtype) * _wanly_e * self.memory_usage_factor) * (1024 * 1024)"
+)
+if stock not in s:
+    print("ERROR: anchor line not found — ComfyUI model_base.py changed; patch needs review", file=sys.stderr)
+    sys.exit(1)
+p.write_text(s.replace(stock, patched, 1))
+print("model_base.py patched: 0.01 -> /tmp/wanly_estimate (cfg-aware VRAM estimate)")


### PR DESCRIPTION
RunPod ran i2v only, so multi-segment jobs fell back to traditional continuation. This adds the full VACE stack for 3090 parity.

**Dockerfile:** clone **ComfyUI-WanVideoWrapper** (KJ) pinned to **1.3.9** (`e926f7a0`) — the 1.3.x minor the 3090 runs — which provides all VACE nodes.

**download_models.sh:** 7 VACE models, HF sources verified (302) by research:
| Local name (= daemon config) | HF source |
|---|---|
| wan2.2_t2v_high/low_noise_14B_fp16 | Comfy-Org/Wan_2.2_ComfyUI_Repackaged |
| Wan2_2_Fun_VACE_module_A14B_HIGH/LOW_fp8…KJ | Kijai/WanVideo_comfy_fp8_scaled (VACE/) |
| Wan2.2-Lightning_T2V…HIGH/LOW_fp16 | lightx2v/Wan2.2-Lightning (renamed) |
| models_t5_umt5-xxl-enc-bf16.pth | Wan-AI/Wan2.1-T2V-14B |

**extra_model_paths.yaml:** add `text_encoders/` (bf16 T5).

⚠️ **Volume must be ≥120GB** (VACE adds ~74GB). ⚠️ **Not build-tested from here** — needs a RunPod validation run (WanVideoWrapper↔ComfyUI compat + the T5 folder mapping are the two things to watch).