### PR TITLE
feat(lynx): stage Wan2.1 T2V + Lynx adapters, add MODEL_PROFILE

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -25,23 +25,72 @@ pip install --no-cache-dir -q "huggingface_hub>=0.34" hf_xet || true
 
 echo "=== Downloading models to ${MODELS_DIR} ==="
 
-MODELS_DIR="$MODELS_DIR" INSIGHTFACE_DIR="$INSIGHTFACE_DIR" python3 - <<'PY'
+MODELS_DIR="$MODELS_DIR" INSIGHTFACE_DIR="$INSIGHTFACE_DIR" MODEL_PROFILE="${MODEL_PROFILE:-full}" python3 - <<'PY'
 import os, shutil
 from huggingface_hub import hf_hub_download
 
 M = os.environ["MODELS_DIR"]
 IF = os.environ["INSIGHTFACE_DIR"]
 WAN = "Comfy-Org/Wan_2.2_ComfyUI_Repackaged"
+KJ = "Kijai/WanVideo_comfy"
+KJ_FP8 = "Kijai/WanVideo_comfy_fp8_scaled"
+
+# MODEL_PROFILE selects which engine families to stage:
+#   full  (default) — everything: Wan2.2 i2v + VACE + Lynx. ~135GB.
+#   lynx            — Lynx only (Wan2.1 T2V base + adapters + T5 + VAE). ~36GB.
+# The lean profile matters on pods with no network volume, where /workspace is
+# ephemeral container disk and the whole set re-downloads on every boot.
+PROFILE = os.environ.get("MODEL_PROFILE", "full").strip().lower()
+if PROFILE not in {"full", "lynx"}:
+    raise SystemExit(f"MODEL_PROFILE must be 'full' or 'lynx', got {PROFILE!r}")
+print(f"=== model profile: {PROFILE} ===")
 
 # (repo, path-in-repo, local destination, repo_type, critical)
 # critical=True  -> generation can't run without it; failure aborts the boot.
 # critical=False -> auxiliary (faceswap / identity-anchor); failure only warns, so a
 #                   gated/moved aux repo never bricks the whole pod boot.
-JOBS = [
-    (WAN, "split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors",
-          f"{M}/clip/umt5_xxl_fp8_e4m3fn_scaled.safetensors", "model", True),
+
+# Shared by every profile: the bf16 T5 the WanVideoWrapper text-encode nodes need,
+# and the Wan2.1 VAE (Lynx decodes through the same VAE as the 2.2 engines).
+COMMON = [
+    ("Wan-AI/Wan2.1-T2V-14B", "models_t5_umt5-xxl-enc-bf16.pth",
+          f"{M}/text_encoders/models_t5_umt5-xxl-enc-bf16.pth", "model", True),
     (WAN, "split_files/vae/wan_2.1_vae.safetensors",
           f"{M}/vae/wan_2.1_vae.safetensors", "model", True),
+]
+
+# === Lynx identity-preserving stack (Wan2.1 T2V-14B + ByteDance Lynx adapters) ===
+# Filenames MUST match the daemon config's lynx_* settings (single source of truth).
+# Kijai's repacks, not the raw ByteDance/Wan-AI repos: these are already single-file
+# safetensors in the layout WanVideoWrapper's loaders expect.
+LYNX = [
+    # Base T2V 14B, scaled fp8 (~14.5GB) — the quant family Kijai's reference graph uses.
+    (KJ_FP8, "T2V/Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors",
+          f"{M}/diffusion_models/Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors", "model", True),
+    # Ref-adapter (dense VAE features cross-attended in the DiT blocks), ~4.2GB.
+    (KJ, "Lynx/Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors",
+          f"{M}/diffusion_models/Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors", "model", True),
+    # ID-adapter, LITE arm + its matched resampler — the default. Kijai's own note reports
+    # the full ip adapter as "very weak"; lite ip + full ref is what his workflow ships.
+    (KJ, "Lynx/Wan2_1-T2V-14B-Lynx_lite_ip_layers_fp16.safetensors",
+          f"{M}/diffusion_models/Wan2_1-T2V-14B-Lynx_lite_ip_layers_fp16.safetensors", "model", True),
+    (KJ, "Lynx/lynx_lite_resampler_fp32.safetensors",
+          f"{M}/diffusion_models/lynx_lite_resampler_fp32.safetensors", "model", True),
+    # FULL arm + matched resampler — the A/B comparison arm. The pair must be swapped
+    # together (mismatched arms load silently and produce garbage identity).
+    (KJ, "Lynx/Wan2_1-T2V-14B-Lynx_full_ip_layers_fp16.safetensors",
+          f"{M}/diffusion_models/Wan2_1-T2V-14B-Lynx_full_ip_layers_fp16.safetensors", "model", True),
+    (KJ, "Lynx/lynx_full_resampler_fp32.safetensors",
+          f"{M}/diffusion_models/lynx_full_resampler_fp32.safetensors", "model", True),
+    # Wan2.1 T2V cfg-step-distill LoRA. The lightx2v i2v LoRAs above are a different
+    # family and do NOT apply to this base.
+    (KJ, "Lightx2v/lightx2v_T2V_14B_cfg_step_distill_v2_lora_rank64_bf16.safetensors",
+          f"{M}/loras/lightx2v_T2V_14B_cfg_step_distill_v2_lora_rank64_bf16.safetensors", "model", True),
+]
+
+FULL_ONLY = [
+    (WAN, "split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+          f"{M}/clip/umt5_xxl_fp8_e4m3fn_scaled.safetensors", "model", True),
     # Base Wan 2.2 i2v diffusion models (high+low) — NATIVE fp8-scaled (~14GB each), matching
     # the 3090. Pre-quantized fp8 with scale tensors, so ComfyUI uses the native scaled-fp8 path
     # (no fp16->fp8 runtime cast, no "manual cast to fp16") — the path that runs fast on the
@@ -74,9 +123,6 @@ JOBS = [
           f"{M}/loras/Wan2.2-Lightning_T2V-A14B-4steps-lora_HIGH_fp16.safetensors", "model", True),
     ("lightx2v/Wan2.2-Lightning", "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1/low_noise_model.safetensors",
           f"{M}/loras/Wan2.2-Lightning_T2V-A14B-4steps-lora_LOW_fp16.safetensors", "model", True),
-    # umt5-xxl text encoder, bf16 .pth (~11GB) — native Wan-AI name/path (Kijai ships a renamed .safetensors).
-    ("Wan-AI/Wan2.1-T2V-14B", "models_t5_umt5-xxl-enc-bf16.pth",
-          f"{M}/text_encoders/models_t5_umt5-xxl-enc-bf16.pth", "model", True),
     # CLIP Vision (PainterLongVideo identity anchoring) -- auxiliary
     ("h94/IP-Adapter", "models/image_encoder/model.safetensors",
           f"{M}/clip_vision/clip_vision_h.safetensors", "model", False),
@@ -84,6 +130,8 @@ JOBS = [
     ("Gourieff/ReActor", "models/inswapper_128.onnx",
           f"{IF}/inswapper_128.onnx", "dataset", False),
 ]
+
+JOBS = COMMON + LYNX + (FULL_ONLY if PROFILE == "full" else [])
 
 for repo, path, dst, repo_type, critical in JOBS:
     name = os.path.basename(dst)
@@ -115,5 +163,49 @@ for repo, path, dst, repo_type, critical in JOBS:
 
 print("=== HF model download complete ===")
 PY
+
+# === Lynx face-model pre-staging ===
+# Lynx pulls two models lazily on first use, both to ephemeral locations outside
+# /workspace. Left alone that means a mid-job download from GitHub (and a hard failure
+# if it is unreachable), so stage them at boot instead.
+#   1. ArcFace IR-SE50 (facexlib) — the encoder Lynx conditions identity on. Note this
+#      is NOT insightface's recognition model: Lynx conditions on facexlib ArcFace and
+#      only uses insightface for the 5-point landmarks.
+#   2. insightface buffalo_l — landmarks for the crop, and the daemon's identity QA.
+WRAPPER_LYNX_FACE="/app/ComfyUI/custom_nodes/ComfyUI-WanVideoWrapper/lynx/face"
+ARCFACE_DIR="${WRAPPER_LYNX_FACE}/facexlib/weights"
+BUFFALO_DIR="${HOME:-/root}/.insightface/models"
+
+echo "=== Staging Lynx face models ==="
+if [ -d "$WRAPPER_LYNX_FACE" ]; then
+    mkdir -p "$ARCFACE_DIR"
+    if [ ! -s "${ARCFACE_DIR}/recognition_arcface_ir_se50.pth" ]; then
+        echo "DOWNLOADING recognition_arcface_ir_se50.pth"
+        curl -fsSL -o "${ARCFACE_DIR}/recognition_arcface_ir_se50.pth" \
+            "https://github.com/xinntao/facexlib/releases/download/v0.1.0/recognition_arcface_ir_se50.pth" \
+            || echo "WARN: ArcFace stage failed; Lynx will retry at first use"
+    else
+        echo "SKIP recognition_arcface_ir_se50.pth (already exists)"
+    fi
+else
+    echo "WARN: WanVideoWrapper lynx/ not found — wrapper predates Lynx (needs >= 1.3.5)"
+fi
+
+mkdir -p "$BUFFALO_DIR"
+if [ ! -d "${BUFFALO_DIR}/buffalo_l" ]; then
+    echo "DOWNLOADING buffalo_l"
+    BUFFALO_DIR="$BUFFALO_DIR" python3 - <<'PY' || echo "WARN: buffalo_l stage failed; insightface will retry at first use"
+import io, os, urllib.request, zipfile
+d = os.environ["BUFFALO_DIR"]
+url = "https://github.com/deepinsight/insightface/releases/download/v0.7/buffalo_l.zip"
+with urllib.request.urlopen(url, timeout=120) as r:
+    data = r.read()
+with zipfile.ZipFile(io.BytesIO(data)) as z:
+    z.extractall(os.path.join(d, "buffalo_l"))
+print(f"OK buffalo_l ({len(data)//1_000_000} MB)")
+PY
+else
+    echo "SKIP buffalo_l (already exists)"
+fi
 
 echo "=== Model download complete ==="


### PR DESCRIPTION
Stages the Lynx identity-preserving model stack (25GB) and adds a `MODEL_PROFILE` env to control what a pod downloads at boot.

## Models

Kijai's repacks, not the raw `Wan-AI`/`ByteDance/lynx` repos — those ship sharded diffusers-format weights, while WanVideoWrapper's loaders want single files in exactly the layout Kijai publishes.

- `Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors` (14.5GB) — base
- Lynx full ref layers (4.2GB)
- **Both** ip arms + their matched resamplers
- `lightx2v_T2V_14B_cfg_step_distill_v2` — the i2v lightx2v LoRAs are a different family and do not apply to this base

Both ip arms are staged because Kijai's own workflow note reports the `full` ip adapter as "very weak" and his shipped workflow uses lite ip + full ref. Which arm actually wins is a measurement, not a model-card claim.

## MODEL_PROFILE

`MODEL_PROFILE=lynx` trims boot download from ~135GB to ~36GB by skipping the 2.2 i2v + VACE stacks. That matters on pods without a network volume, where `/workspace` is ephemeral and everything re-downloads each boot. Default stays `full`, so existing pods are unaffected.

## Face model pre-staging

Lynx otherwise fetches two models lazily, mid-job, to ephemeral paths — a hard failure if GitHub is unreachable at that moment:
- facexlib ArcFace IR-SE50 (what Lynx actually conditions identity on)
- insightface buffalo_l (landmarks, plus the daemon's identity QA)

## Note

Merging this triggers the image rebuild (`build-push.yml` on main → `davidjbarnes/wanly22-runpod:latest`). A pod also needs a template pointing at the new image with `MODEL_PROFILE=lynx` and ≥60GB container disk.