### PR TITLE
fix(lynx): use the fp16 base — an fp8 base is incompatible with the adapters

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -64,9 +64,13 @@ COMMON = [
 # Kijai's repacks, not the raw ByteDance/Wan-AI repos: these are already single-file
 # safetensors in the layout WanVideoWrapper's loaders expect.
 LYNX = [
-    # Base T2V 14B, scaled fp8 (~14.5GB) — the quant family Kijai's reference graph uses.
-    (KJ_FP8, "T2V/Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors",
-          f"{M}/diffusion_models/Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors", "model", True),
+    # Base T2V 14B, fp16 (~28GB). NOT fp8: the Lynx adapters are plain nn.Linear and are
+    # not wrapped by the wrapper's fp8-aware linear, so an fp8 base casts their weights to
+    # fp8 while activations stay fp16 and the sampler dies with "self and mat2 must have
+    # the same dtype, but got Half and Float8_e4m3fn". Block swap carries the larger
+    # checkpoint, exactly as the VACE path already runs 28GB fp16 models on 24GB cards.
+    ("Comfy-Org/Wan_2.1_ComfyUI_repackaged", "split_files/diffusion_models/wan2.1_t2v_14B_fp16.safetensors",
+          f"{M}/diffusion_models/wan2.1_t2v_14B_fp16.safetensors", "model", True),
     # Ref-adapter (dense VAE features cross-attended in the DiT blocks), ~4.2GB.
     (KJ, "Lynx/Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors",
           f"{M}/diffusion_models/Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors", "model", True),

--- a/start.sh
+++ b/start.sh
@@ -48,6 +48,9 @@ QUEUE_URL=${QUEUE_URL:-http://api.wanly22.com:8001}
 FRIENDLY_NAME=${FRIENDLY_NAME:-runpod-${RUNPOD_POD_ID:-unknown}}
 COMFYUI_URL=http://localhost:8188
 COMFYUI_PATH=/app/ComfyUI
+# Must match the MODEL_PROFILE used by download_models.sh above: the daemon validates
+# exactly the model families it was provisioned with, and a mismatch fails startup.
+MODEL_PROFILE=${MODEL_PROFILE:-full}
 LORA_CACHE_DIR=/workspace/models/loras
 UNET_HIGH_MODEL=${UNET_HIGH_MODEL:-wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors}
 UNET_LOW_MODEL=${UNET_LOW_MODEL:-wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors}


### PR DESCRIPTION
Lynx repeatedly failed at `WanVideoSampler`:

```
self and mat2 must have the same dtype, but got Half and Float8_e4m3fn
```

## Root cause

The Lynx adapters are **plain `nn.Linear`** (`lynx/modules.py`: `to_k_ip`, `to_v_ip`, `to_k_ref`, `to_v_ref`), so they are not wrapped by the wrapper's fp8-aware linear layer. With an fp8 base, their weights get cast to fp8 while activations stay fp16 — `self` (Half) × `mat2` (Float8_e4m3fn).

Confirmed this is **not** a quantization-setting issue: `fp8_e4m3fn_scaled` and `disabled` fail identically. The base checkpoint's dtype is the lever, not the loader flag.

Kijai's reference workflow gets away with an fp8 base only via `base_precision: fp16_fast`, which needs a torch 2.7 nightly our image doesn't ship — and that's the failure we hit when I tried to match him.

## Fix

`wan2.1_t2v_14B_fp16` (Comfy-Org repackage) instead of the fp8 build. 28 GB rather than 14.5 GB; block swap carries it, exactly as the VACE path already runs 28 GB fp16 models on 24 GB cards. Nothing in the graph is fp8 now.

Test asserts no fp8 anywhere in the loader inputs, so this can't regress silently.

Paired with wanly-runpod: the fp16 base added to the lynx download profile (~50 GB total, fits the 80 GB volume).