### PR TITLE
Stage only the native i2v models (~39GB, was ~170GB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,6 @@ ARG FRAME_INTERP_COMMIT=26545cc2dd95bc3d27f056016300673bdeee78f5
 ARG VHS_COMMIT=4ee72c065db22c9d96c2427954dc69e7b908444b
 ARG REACTOR_COMMIT=6ad6b35a4df250d14cb2abf0808c9ffedf59f747
 ARG PAINTER_COMMIT=889b4ff67909561e52d6ae023f5b9e8c33fdba94
-# WanVideoWrapper (KJ) — provides the VACE nodes (WanVideoVACEEncode/Sampler/...).
-# Pinned to 1.3.9 (e926f7a0), the same 1.3.x minor the 3090 runs (its pyproject reports 1.3.3;
-# there is no matching git tag, and VACE node inputs are stable across 1.3.x).
-ARG WANVIDEO_COMMIT=e926f7a069e3efc25bdcc78e1bf65c39ac1a2cd4
 
 # Custom nodes: Frame Interpolation (RIFE)
 # Install cupy-cuda12x directly (pre-built wheel) — the requirements file's cupy-wheel
@@ -77,12 +73,10 @@ RUN git clone https://github.com/princepainter/ComfyUI-PainterLongVideo.git \
     ComfyUI/custom_nodes/ComfyUI-PainterLongVideo && \
     git -C ComfyUI/custom_nodes/ComfyUI-PainterLongVideo checkout ${PAINTER_COMMIT}
 
-# Custom nodes: WanVideoWrapper (KJ) — the VACE continuation path (nodes 5xx).
-# Directory name matches the daemon's node_checker expectation.
-RUN git clone https://github.com/kijai/ComfyUI-WanVideoWrapper.git \
-    ComfyUI/custom_nodes/ComfyUI-WanVideoWrapper && \
-    git -C ComfyUI/custom_nodes/ComfyUI-WanVideoWrapper checkout ${WANVIDEO_COMMIT} && \
-    pip install --no-cache-dir -r ComfyUI/custom_nodes/ComfyUI-WanVideoWrapper/requirements.txt
+# NOTE: WanVideoWrapper (KJ) was installed here for the VACE continuation and Lynx paths.
+# Both engines were retired from wanly-gpu-daemon, and nothing on the native i2v path uses
+# its nodes, so it is no longer installed — its unpinned requirements were a recurring
+# source of dependency skew against this image's torch 2.6.0 / CUDA 12.4.
 
 # Daemon Python dependencies (daemon code itself is cloned at boot for freshness)
 RUN pip install --no-cache-dir httpx pydantic-settings python-dotenv websockets

--- a/download_models.sh
+++ b/download_models.sh
@@ -25,74 +25,30 @@ pip install --no-cache-dir -q "huggingface_hub>=0.34" hf_xet || true
 
 echo "=== Downloading models to ${MODELS_DIR} ==="
 
-MODELS_DIR="$MODELS_DIR" INSIGHTFACE_DIR="$INSIGHTFACE_DIR" MODEL_PROFILE="${MODEL_PROFILE:-full}" python3 - <<'PY'
+MODELS_DIR="$MODELS_DIR" INSIGHTFACE_DIR="$INSIGHTFACE_DIR" python3 - <<'PY'
 import os, shutil
 from huggingface_hub import hf_hub_download
 
 M = os.environ["MODELS_DIR"]
 IF = os.environ["INSIGHTFACE_DIR"]
 WAN = "Comfy-Org/Wan_2.2_ComfyUI_Repackaged"
-KJ = "Kijai/WanVideo_comfy"
-KJ_FP8 = "Kijai/WanVideo_comfy_fp8_scaled"
 
-# MODEL_PROFILE selects which engine families to stage:
-#   full  (default) — everything: Wan2.2 i2v + VACE + Lynx. ~135GB.
-#   lynx            — Lynx only (Wan2.1 T2V base + adapters + T5 + VAE). ~36GB.
-# The lean profile matters on pods with no network volume, where /workspace is
-# ephemeral container disk and the whole set re-downloads on every boot.
-PROFILE = os.environ.get("MODEL_PROFILE", "full").strip().lower()
-if PROFILE not in {"full", "lynx"}:
-    raise SystemExit(f"MODEL_PROFILE must be 'full' or 'lynx', got {PROFILE!r}")
-print(f"=== model profile: {PROFILE} ===")
-
+# One engine: native Wan 2.2 i2v. ~39GB total.
+#
+# The VACE and Lynx stacks used to be staged here too (behind a MODEL_PROFILE switch),
+# which pushed the full set past 170GB — more than the volume holds, so the last file
+# to download failed and took the whole boot with it. Both engines were retired from
+# wanly-gpu-daemon; this list must stay in sync with MODEL_CHECKS in its
+# daemon/model_validator.py, since the daemon fails startup on anything missing.
+#
 # (repo, path-in-repo, local destination, repo_type, critical)
 # critical=True  -> generation can't run without it; failure aborts the boot.
 # critical=False -> auxiliary (faceswap / identity-anchor); failure only warns, so a
 #                   gated/moved aux repo never bricks the whole pod boot.
 
-# Shared by every profile: the bf16 T5 the WanVideoWrapper text-encode nodes need,
-# and the Wan2.1 VAE (Lynx decodes through the same VAE as the 2.2 engines).
-COMMON = [
-    ("Wan-AI/Wan2.1-T2V-14B", "models_t5_umt5-xxl-enc-bf16.pth",
-          f"{M}/text_encoders/models_t5_umt5-xxl-enc-bf16.pth", "model", True),
+JOBS = [
     (WAN, "split_files/vae/wan_2.1_vae.safetensors",
           f"{M}/vae/wan_2.1_vae.safetensors", "model", True),
-]
-
-# === Lynx identity-preserving stack (Wan2.1 T2V-14B + ByteDance Lynx adapters) ===
-# Filenames MUST match the daemon config's lynx_* settings (single source of truth).
-# Kijai's repacks, not the raw ByteDance/Wan-AI repos: these are already single-file
-# safetensors in the layout WanVideoWrapper's loaders expect.
-LYNX = [
-    # Base T2V 14B, fp16 (~28GB). NOT fp8: the Lynx adapters are plain nn.Linear and are
-    # not wrapped by the wrapper's fp8-aware linear, so an fp8 base casts their weights to
-    # fp8 while activations stay fp16 and the sampler dies with "self and mat2 must have
-    # the same dtype, but got Half and Float8_e4m3fn". Block swap carries the larger
-    # checkpoint, exactly as the VACE path already runs 28GB fp16 models on 24GB cards.
-    ("Comfy-Org/Wan_2.1_ComfyUI_repackaged", "split_files/diffusion_models/wan2.1_t2v_14B_fp16.safetensors",
-          f"{M}/diffusion_models/wan2.1_t2v_14B_fp16.safetensors", "model", True),
-    # Ref-adapter (dense VAE features cross-attended in the DiT blocks), ~4.2GB.
-    (KJ, "Lynx/Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors",
-          f"{M}/diffusion_models/Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors", "model", True),
-    # ID-adapter, LITE arm + its matched resampler — the default. Kijai's own note reports
-    # the full ip adapter as "very weak"; lite ip + full ref is what his workflow ships.
-    (KJ, "Lynx/Wan2_1-T2V-14B-Lynx_lite_ip_layers_fp16.safetensors",
-          f"{M}/diffusion_models/Wan2_1-T2V-14B-Lynx_lite_ip_layers_fp16.safetensors", "model", True),
-    (KJ, "Lynx/lynx_lite_resampler_fp32.safetensors",
-          f"{M}/diffusion_models/lynx_lite_resampler_fp32.safetensors", "model", True),
-    # FULL arm + matched resampler — the A/B comparison arm. The pair must be swapped
-    # together (mismatched arms load silently and produce garbage identity).
-    (KJ, "Lynx/Wan2_1-T2V-14B-Lynx_full_ip_layers_fp16.safetensors",
-          f"{M}/diffusion_models/Wan2_1-T2V-14B-Lynx_full_ip_layers_fp16.safetensors", "model", True),
-    (KJ, "Lynx/lynx_full_resampler_fp32.safetensors",
-          f"{M}/diffusion_models/lynx_full_resampler_fp32.safetensors", "model", True),
-    # Wan2.1 T2V cfg-step-distill LoRA. The lightx2v i2v LoRAs above are a different
-    # family and do NOT apply to this base.
-    (KJ, "Lightx2v/lightx2v_T2V_14B_cfg_step_distill_v2_lora_rank64_bf16.safetensors",
-          f"{M}/loras/lightx2v_T2V_14B_cfg_step_distill_v2_lora_rank64_bf16.safetensors", "model", True),
-]
-
-FULL_ONLY = [
     (WAN, "split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors",
           f"{M}/clip/umt5_xxl_fp8_e4m3fn_scaled.safetensors", "model", True),
     # Base Wan 2.2 i2v diffusion models (high+low) — NATIVE fp8-scaled (~14GB each), matching
@@ -107,26 +63,6 @@ FULL_ONLY = [
           f"{M}/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors", "model", True),
     (WAN, "split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors",
           f"{M}/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors", "model", True),
-    # === VACE continuation stack (identity-anchored multi-segment) ===
-    # Local filenames MUST match the daemon config's vace_* settings (single source of truth), even
-    # where the HF path differs. Critical: with the WanVideoWrapper nodes installed, the daemon
-    # routes continuations to VACE, so a booted pod must have these or VACE segments fail at load.
-    # T2V base (fp16, ~28GB each) — same weights the 3090 uses; block-swap keeps it on 24GB.
-    (WAN, "split_files/diffusion_models/wan2.2_t2v_high_noise_14B_fp16.safetensors",
-          f"{M}/diffusion_models/wan2.2_t2v_high_noise_14B_fp16.safetensors", "model", True),
-    (WAN, "split_files/diffusion_models/wan2.2_t2v_low_noise_14B_fp16.safetensors",
-          f"{M}/diffusion_models/wan2.2_t2v_low_noise_14B_fp16.safetensors", "model", True),
-    # Fun-VACE modules (fp8, ~3GB each) — Kijai's VACE/ subfolder.
-    ("Kijai/WanVideo_comfy_fp8_scaled", "VACE/Wan2_2_Fun_VACE_module_A14B_HIGH_fp8_e4m3fn_scaled_KJ.safetensors",
-          f"{M}/diffusion_models/Wan2_2_Fun_VACE_module_A14B_HIGH_fp8_e4m3fn_scaled_KJ.safetensors", "model", True),
-    ("Kijai/WanVideo_comfy_fp8_scaled", "VACE/Wan2_2_Fun_VACE_module_A14B_LOW_fp8_e4m3fn_scaled_KJ.safetensors",
-          f"{M}/diffusion_models/Wan2_2_Fun_VACE_module_A14B_LOW_fp8_e4m3fn_scaled_KJ.safetensors", "model", True),
-    # T2V 4-step Lightning distill LoRAs (lightx2v repo names them high/low_noise_model.safetensors;
-    # saved under the daemon's expected names). Rank-64 Seko V1.1.
-    ("lightx2v/Wan2.2-Lightning", "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1/high_noise_model.safetensors",
-          f"{M}/loras/Wan2.2-Lightning_T2V-A14B-4steps-lora_HIGH_fp16.safetensors", "model", True),
-    ("lightx2v/Wan2.2-Lightning", "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1/low_noise_model.safetensors",
-          f"{M}/loras/Wan2.2-Lightning_T2V-A14B-4steps-lora_LOW_fp16.safetensors", "model", True),
     # CLIP Vision (PainterLongVideo identity anchoring) -- auxiliary
     ("h94/IP-Adapter", "models/image_encoder/model.safetensors",
           f"{M}/clip_vision/clip_vision_h.safetensors", "model", False),
@@ -134,8 +70,6 @@ FULL_ONLY = [
     ("Gourieff/ReActor", "models/inswapper_128.onnx",
           f"{IF}/inswapper_128.onnx", "dataset", False),
 ]
-
-JOBS = COMMON + LYNX + (FULL_ONLY if PROFILE == "full" else [])
 
 for repo, path, dst, repo_type, critical in JOBS:
     name = os.path.basename(dst)
@@ -168,48 +102,5 @@ for repo, path, dst, repo_type, critical in JOBS:
 print("=== HF model download complete ===")
 PY
 
-# === Lynx face-model pre-staging ===
-# Lynx pulls two models lazily on first use, both to ephemeral locations outside
-# /workspace. Left alone that means a mid-job download from GitHub (and a hard failure
-# if it is unreachable), so stage them at boot instead.
-#   1. ArcFace IR-SE50 (facexlib) — the encoder Lynx conditions identity on. Note this
-#      is NOT insightface's recognition model: Lynx conditions on facexlib ArcFace and
-#      only uses insightface for the 5-point landmarks.
-#   2. insightface buffalo_l — landmarks for the crop, and the daemon's identity QA.
-WRAPPER_LYNX_FACE="/app/ComfyUI/custom_nodes/ComfyUI-WanVideoWrapper/lynx/face"
-ARCFACE_DIR="${WRAPPER_LYNX_FACE}/facexlib/weights"
-BUFFALO_DIR="${HOME:-/root}/.insightface/models"
-
-echo "=== Staging Lynx face models ==="
-if [ -d "$WRAPPER_LYNX_FACE" ]; then
-    mkdir -p "$ARCFACE_DIR"
-    if [ ! -s "${ARCFACE_DIR}/recognition_arcface_ir_se50.pth" ]; then
-        echo "DOWNLOADING recognition_arcface_ir_se50.pth"
-        curl -fsSL -o "${ARCFACE_DIR}/recognition_arcface_ir_se50.pth" \
-            "https://github.com/xinntao/facexlib/releases/download/v0.1.0/recognition_arcface_ir_se50.pth" \
-            || echo "WARN: ArcFace stage failed; Lynx will retry at first use"
-    else
-        echo "SKIP recognition_arcface_ir_se50.pth (already exists)"
-    fi
-else
-    echo "WARN: WanVideoWrapper lynx/ not found — wrapper predates Lynx (needs >= 1.3.5)"
-fi
-
-mkdir -p "$BUFFALO_DIR"
-if [ ! -d "${BUFFALO_DIR}/buffalo_l" ]; then
-    echo "DOWNLOADING buffalo_l"
-    BUFFALO_DIR="$BUFFALO_DIR" python3 - <<'PY' || echo "WARN: buffalo_l stage failed; insightface will retry at first use"
-import io, os, urllib.request, zipfile
-d = os.environ["BUFFALO_DIR"]
-url = "https://github.com/deepinsight/insightface/releases/download/v0.7/buffalo_l.zip"
-with urllib.request.urlopen(url, timeout=120) as r:
-    data = r.read()
-with zipfile.ZipFile(io.BytesIO(data)) as z:
-    z.extractall(os.path.join(d, "buffalo_l"))
-print(f"OK buffalo_l ({len(data)//1_000_000} MB)")
-PY
-else
-    echo "SKIP buffalo_l (already exists)"
-fi
 
 echo "=== Model download complete ==="

--- a/start.sh
+++ b/start.sh
@@ -48,9 +48,6 @@ QUEUE_URL=${QUEUE_URL:-http://api.wanly22.com:8001}
 FRIENDLY_NAME=${FRIENDLY_NAME:-runpod-${RUNPOD_POD_ID:-unknown}}
 COMFYUI_URL=http://localhost:8188
 COMFYUI_PATH=/app/ComfyUI
-# Must match the MODEL_PROFILE used by download_models.sh above: the daemon validates
-# exactly the model families it was provisioned with, and a mismatch fails startup.
-MODEL_PROFILE=${MODEL_PROFILE:-full}
 LORA_CACHE_DIR=/workspace/models/loras
 UNET_HIGH_MODEL=${UNET_HIGH_MODEL:-wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors}
 UNET_LOW_MODEL=${UNET_LOW_MODEL:-wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors}


### PR DESCRIPTION
Fixes the boot failure. Companion PR: DavidJBarnes/wanly-gpu-daemon#89.

## The failure

```
SKIP wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors (already exists)
DOWNLOADING wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors
Traceback (most recent call last):
  File "<stdin>", line 130, in <module>
  ...huggingface_hub/file_download.py", line 992, in hf_hub_download
```

The `full` profile staged Wan2.2 i2v + VACE + Lynx + the bf16 T5 — around 170GB onto a ≥120GB volume. `set -e` plus `critical=True` means one failed download aborts the whole boot.

## Dropped

- **Lynx stack** — Wan2.1 T2V-14B fp16 base (~28GB), both ip/ref adapter arms, both resamplers, the T2V distill LoRA
- **VACE stack** — T2V fp16 high/low (~28GB each), Fun-VACE modules, T2V Lightning LoRAs
- **`models_t5_umt5-xxl-enc-bf16.pth`** (~11GB) — only the WanVideoWrapper text-encode nodes used it, and both consumers are gone
- **`MODEL_PROFILE`** — nothing left to switch between (also removed from `start.sh`)
- **Lynx face-model pre-staging** — facexlib ArcFace and buffalo_l. Both consumers were Lynx (the face crop and the daemon's identity QA). ReActor fetches what it needs on first use, exactly as it did before Lynx landed in #25.
- **WanVideoWrapper from the Dockerfile** — VACE/Lynx were its only consumers. Nothing on the native i2v path uses its nodes, and `node_checker.py` never required it. Its unpinned requirements were a recurring source of dependency skew against this image's torch 2.6.0 / CUDA 12.4.

## Still staged (8 files, ~39GB)

| | file |
|---|---|
| CRITICAL | `wan_2.1_vae.safetensors` |
| CRITICAL | `umt5_xxl_fp8_e4m3fn_scaled.safetensors` |
| CRITICAL | `wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors` |
| CRITICAL | `wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors` |
| CRITICAL | `wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors` |
| CRITICAL | `wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors` |
| aux | `clip_vision_h.safetensors` (PainterLongVideo identity anchor) |
| aux | `inswapper_128.onnx` (ReActor) |

This list must stay in sync with `MODEL_CHECKS` in the daemon's `daemon/model_validator.py` — the daemon fails startup on anything missing.

## Verification

`bash -n` passes on both scripts; the heredoc parses and evaluates to exactly the 8 entries above. **Needs an image rebuild** for the Dockerfile change.

## Caveat

The traceback was truncated before the exception type, so disk exhaustion is inferred from the size math rather than confirmed. If the real cause was a 404 on that specific file, it is still in the list and the boot will still fail.