### PR TITLE
Add FaceFusion to the image, and stop silently fighting over onnxruntime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ ARG FRAME_INTERP_COMMIT=26545cc2dd95bc3d27f056016300673bdeee78f5
 ARG VHS_COMMIT=4ee72c065db22c9d96c2427954dc69e7b908444b
 ARG REACTOR_COMMIT=6ad6b35a4df250d14cb2abf0808c9ffedf59f747
 ARG PAINTER_COMMIT=889b4ff67909561e52d6ae023f5b9e8c33fdba94
+ARG FACEFUSION_COMMIT=3e73829
 
 # Custom nodes: Frame Interpolation (RIFE)
 # Install cupy-cuda12x directly (pre-built wheel) — the requirements file's cupy-wheel
@@ -77,13 +78,65 @@ RUN git clone https://github.com/princepainter/ComfyUI-PainterLongVideo.git \
     ComfyUI/custom_nodes/ComfyUI-PainterLongVideo && \
     git -C ComfyUI/custom_nodes/ComfyUI-PainterLongVideo checkout ${PAINTER_COMMIT}
 
+# Custom nodes: FaceFusion — the swapper the validated identity recipe uses.
+# ReActor (above) selects the target face by POSITION only; FaceFusion is what the recipe and
+# the console default (faceswap_method=facefusion) build node 183 `AdvancedSwapFaceImage` from.
+# Without this every job using the recipe fails at ComfyUI prompt validation.
+#
+# A clean clone is NOT sufficient. See patches/README.md — the node needs the NSFW gate
+# disabled, and an import shim without which it does not load at all on this ComfyUI build.
+COPY patches/ /app/patches/
+RUN git clone https://github.com/huygiatrng/Facefusion_comfyui.git \
+    ComfyUI/custom_nodes/Facefusion_comfyui && \
+    git -C ComfyUI/custom_nodes/Facefusion_comfyui checkout ${FACEFUSION_COMMIT} && \
+    pip install --no-cache-dir -r ComfyUI/custom_nodes/Facefusion_comfyui/requirements.txt && \
+    cp /app/patches/comfy_compat.py ComfyUI/custom_nodes/Facefusion_comfyui/facefusion_api/nodes/comfy_compat.py && \
+    git -C ComfyUI/custom_nodes/Facefusion_comfyui apply /app/patches/facefusion_comfyui.patch && \
+    python3 -c "import ast,sys; ast.parse(open('ComfyUI/custom_nodes/Facefusion_comfyui/content_filter/content_filter.py').read())" && \
+    grep -q 'NSFW filter disabled' ComfyUI/custom_nodes/Facefusion_comfyui/content_filter/content_filter.py && \
+    grep -q 'from .comfy_compat import' ComfyUI/custom_nodes/Facefusion_comfyui/facefusion_api/nodes/base.py
+
+# Bake the FaceFusion models the recipe actually uses (~900MB). The node self-downloads on
+# first use into its OWN directory, which lives in the image rather than on the volume -- so
+# without this every container start re-downloads them and the first job stalls. GitHub
+# releases, not HuggingFace, so download_models.sh (hf_hub_download only) cannot stage them.
+#
+# This is exactly the set workflow_builder.py asks for:
+#   inswapper_128         face_swapper_model (David's visual pick over hyperswap_1c_256)
+#   retinaface_10g        face_detector_model
+#   xseg_1                face_occluder_model  -- matters when hands cross the face
+#   bisenet_resnet_34     face_parser_model
+#   arcface_w600k_r50     recognizer, always loaded
+#   scrfd_2.5g            the node's DEFAULT detector; 3MB, kept as a fallback
+ARG FF_ASSETS=https://github.com/facefusion/facefusion-assets/releases/download
+RUN FFM=ComfyUI/custom_nodes/Facefusion_comfyui/models && mkdir -p $FFM && \
+    for u in models-3.0.0/inswapper_128.onnx \
+             models-3.0.0/arcface_w600k_r50.onnx \
+             models-3.0.0/retinaface_10g.onnx \
+             models-3.0.0/scrfd_2.5g.onnx \
+             models-3.0.0/bisenet_resnet_34.onnx \
+             models-3.1.0/xseg_1.onnx ; do \
+        f=$(basename $u); \
+        curl -fsSL --retry 3 --retry-delay 5 -o "$FFM/$f" "${FF_ASSETS}/$u" || exit 1; \
+        [ -s "$FFM/$f" ] || { echo "empty download: $f"; exit 1; }; \
+    done && \
+    ls -la $FFM
+
 # NOTE: WanVideoWrapper (KJ) was installed here for the VACE continuation and Lynx paths.
 # Both engines were retired from wanly-gpu-daemon, and nothing on the native i2v path uses
 # its nodes, so it is no longer installed — its unpinned requirements were a recurring
 # source of dependency skew against this image's torch 2.6.0 / CUDA 12.4.
 
-# Daemon Python dependencies (daemon code itself is cloned at boot for freshness)
-RUN pip install --no-cache-dir httpx pydantic-settings python-dotenv websockets
+# Daemon Python dependencies. The daemon CODE is cloned at boot for freshness, so its
+# requirements.txt is not present at build time -- but hand-listing the deps here means the
+# list silently rots as the daemon grows. It already had: numpy, onnxruntime,
+# opencv-python-headless, Pillow, pyyaml and insightface were all missing, and identity
+# scoring only worked because ComfyUI and the ReActor layer happened to pull them in.
+#
+# Pinned copy of daemon/requirements.txt. When that file changes, this must change with it --
+# start.sh re-checks at boot and warns loudly if they have diverged.
+COPY daemon-requirements.txt /app/daemon-requirements.txt
+RUN pip install --no-cache-dir -r /app/daemon-requirements.txt
 
 # Config and scripts
 COPY extra_model_paths.yaml /app/ComfyUI/extra_model_paths.yaml

--- a/daemon-requirements.txt
+++ b/daemon-requirements.txt
@@ -1,0 +1,24 @@
+# Pinned copy of wanly-gpu-daemon/requirements.txt for the image build. The daemon code is
+# cloned at BOOT, so its own requirements.txt does not exist at build time. start.sh diffs this
+# against the cloned copy and warns if they have drifted.
+#
+# TWO deliberate exclusions -- both would collide with packages already installed above:
+#
+#   onnxruntime              onnxruntime-gpu is installed for ReActor/FaceFusion and provides
+#                            the same `onnxruntime` module. Installing the CPU build on top
+#                            replaces it and silently drops GPU execution for the swap.
+#                            The daemon only needs CPUExecutionProvider (identity scoring runs
+#                            on CPU on purpose, to leave the GPU to generation), and the -gpu
+#                            build provides that too.
+#
+#   opencv-python-headless   opencv-python is already pulled in by ReActor and FaceFusion, and
+#                            both packages provide `cv2`. Installing both leaves whichever
+#                            landed last, which is a coin toss across rebuilds.
+httpx
+numpy
+Pillow
+pydantic-settings
+python-dotenv
+pyyaml
+websockets
+insightface==0.7.3

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,36 @@
+# Facefusion_comfyui patches
+
+`Facefusion_comfyui` will not work out of the box for this pipeline. These carry the changes
+that were living, uncommitted, in the 3090's working tree — the setup only worked because of
+edits that existed on exactly one machine and in no repository.
+
+Applied in the Dockerfile after the pinned clone.
+
+## facefusion_comfyui.patch
+
+**`content_filter/content_filter.py`** — one line, `return False`, disabling the NSFW gate.
+Stock, the filter blocks this content outright. Note the gate is two files: this detector plus
+a self-hash in `core.py`, so a future upgrade that changes the file re-breaks it and the
+constant has to be recomputed. Do not substitute someone else's patched fork.
+
+**`facefusion_api/nodes/base.py`** — imports `bytesio_to_image_tensor` / `tensor_to_bytesio`
+from a local shim instead of `comfy_api_nodes.util`, which does not exist in the ComfyUI build
+we pin. Without this the node fails to IMPORT, so every faceswap workflow dies at prompt
+validation rather than at runtime.
+
+**`facefusion_api/swap_local.py`** — uncomments three `print` statements. Diagnostic only, but
+they are the only visibility into which face the swap actually selected, and selection is
+positional (see below), so keep them.
+
+## comfy_compat.py
+
+The shim `base.py` imports. Copied to `facefusion_api/nodes/comfy_compat.py`; it is untracked
+upstream, so it cannot travel in the patch.
+
+## Worth knowing
+
+Face selection in this node is POSITIONAL, not identity-based: `reference_image` and
+`reference_face_distance` are declared as node inputs and never passed to the swap, and the
+SAME index selects both the source and the target face. It works today because the subject sits
+at position 0 under `left-right` ordering. `utils.py` already contains
+`find_similar_faces(reference_face, ...)`; it is simply not wired into `swap_local.py`.

--- a/patches/comfy_compat.py
+++ b/patches/comfy_compat.py
@@ -1,0 +1,41 @@
+"""
+Compatibility shim for missing comfy_api_nodes.util functions.
+"""
+from io import BytesIO
+import torch
+import numpy as np
+from PIL import Image
+
+
+def bytesio_to_image_tensor(buffer: BytesIO) -> torch.Tensor:
+    """Convert BytesIO image to tensor in ComfyUI format [B, H, W, C]."""
+    buffer.seek(0)
+    image = Image.open(buffer).convert('RGB')
+    img_array = np.array(image).astype(np.float32) / 255.0
+    tensor = torch.from_numpy(img_array).unsqueeze(0)  # Add batch dim
+    return tensor
+
+
+def tensor_to_bytesio(tensor: torch.Tensor, mime_type: str = 'image/png') -> BytesIO:
+    """Convert tensor in ComfyUI format [B, H, W, C] to BytesIO."""
+    # Handle batch dimension
+    if tensor.dim() == 4:
+        tensor = tensor[0]  # Take first image from batch
+    
+    # Convert to numpy and scale to 0-255
+    img_array = (tensor.cpu().numpy() * 255).clip(0, 255).astype(np.uint8)
+    
+    # Create PIL image
+    image = Image.fromarray(img_array)
+    
+    # Save to BytesIO
+    buffer = BytesIO()
+    format_map = {
+        'image/png': 'PNG',
+        'image/jpeg': 'JPEG', 
+        'image/webp': 'WEBP'
+    }
+    fmt = format_map.get(mime_type, 'PNG')
+    image.save(buffer, format=fmt)
+    buffer.seek(0)
+    return buffer

--- a/patches/facefusion_comfyui.patch
+++ b/patches/facefusion_comfyui.patch
@@ -1,0 +1,51 @@
+diff --git a/content_filter/content_filter.py b/content_filter/content_filter.py
+index dde12b8..e3e9207 100644
+--- a/content_filter/content_filter.py
++++ b/content_filter/content_filter.py
+@@ -324,6 +324,7 @@ def get_filter() -> ContentFilter:
+ 
+ 
+ def analyse_frame(frame: np.ndarray) -> bool:
++    return False  # NSFW filter disabled
+     """
+     Analyse frame for NSFW content.
+     
+diff --git a/facefusion_api/nodes/base.py b/facefusion_api/nodes/base.py
+index 0a4b3fb..1c82ff4 100644
+--- a/facefusion_api/nodes/base.py
++++ b/facefusion_api/nodes/base.py
+@@ -11,7 +11,7 @@ import numpy as np
+ from comfy.comfy_types import IO
+ from comfy_api.input_impl.video_types import VideoFromComponents
+ from comfy_api.util import VideoComponents
+-from comfy_api_nodes.util import bytesio_to_image_tensor, tensor_to_bytesio
++from .comfy_compat import bytesio_to_image_tensor, tensor_to_bytesio
+ from httpx import Client as HttpClient, Headers
+ from httpx_retries import Retry, RetryTransport
+ from torch import Tensor
+diff --git a/facefusion_api/swap_local.py b/facefusion_api/swap_local.py
+index 16f25c8..057c781 100644
+--- a/facefusion_api/swap_local.py
++++ b/facefusion_api/swap_local.py
+@@ -60,11 +60,11 @@ def swap_faces_local(
+     target_faces = detect_faces(target_image, score_threshold, sort_order, face_detector_model)
+     
+     if not source_faces:
+-        # print("[LocalSwap] No faces detected in source image")
++        print("[LocalSwap] No faces detected in source image")
+         return target_image
+     
+     if not target_faces:
+-        # print("[LocalSwap] No faces detected in target image")
++        print("[LocalSwap] No faces detected in target image")
+         return target_image
+     
+     # Select source face
+@@ -104,6 +104,6 @@ def swap_faces_local(
+             face_mask_types, face_mask_areas, face_mask_regions, face_mask_padding
+         )
+     
+-    # print("[LocalSwap] Face swap completed")
++    print("[LocalSwap] Face swap completed")
+     return result
+ 

--- a/start.sh
+++ b/start.sh
@@ -35,8 +35,42 @@ else
     git clone --depth 1 "$DAEMON_REPO" "$DAEMON_DIR"
 fi
 
-# Install/update daemon deps
-pip install --no-cache-dir -q -r "$DAEMON_DIR/requirements.txt" 2>/dev/null || true
+# ---------- Daemon deps ----------
+# The image already installed these from daemon-requirements.txt at build time. This only has
+# to catch deps ADDED to the daemon since the image was built.
+#
+# It used to be `pip install -r requirements.txt 2>/dev/null || true`, which had two problems:
+# every error was swallowed, so a failed install looked identical to a clean one; and it
+# reinstalled onnxruntime (CPU) over the onnxruntime-gpu that ReActor and FaceFusion need,
+# plus opencv-python-headless over opencv-python -- both silently, on every boot, because the
+# two packages in each pair provide the same module.
+#
+# So: skip the two that collide, install the rest, and SAY SO when something fails.
+SKIP_DEPS="onnxruntime|opencv-python-headless"
+if [ -f "$DAEMON_DIR/requirements.txt" ]; then
+    MISSING=""
+    while read -r dep; do
+        [ -z "$dep" ] && continue
+        case "$dep" in \#*) continue ;; esac
+        echo "$dep" | grep -qE "^($SKIP_DEPS)([=<>]|$)" && continue
+        mod=$(echo "$dep" | sed -E 's/[=<>!].*//')
+        pip show "$mod" >/dev/null 2>&1 || MISSING="$MISSING $dep"
+    done < "$DAEMON_DIR/requirements.txt"
+    if [ -n "$MISSING" ]; then
+        echo "Daemon deps added since image build:$MISSING"
+        # shellcheck disable=SC2086
+        pip install --no-cache-dir -q $MISSING || echo "!! DAEMON DEP INSTALL FAILED:$MISSING"
+    fi
+fi
+
+# Loud, early warning if the image's pinned copy has drifted from the daemon's actual list.
+if [ -f /app/daemon-requirements.txt ] && [ -f "$DAEMON_DIR/requirements.txt" ]; then
+    DRIFT=$(comm -13 \
+        <(grep -vE '^\s*(#|$)' /app/daemon-requirements.txt | sed -E 's/[=<>!].*//' | sort -u) \
+        <(grep -vE '^\s*(#|$)' "$DAEMON_DIR/requirements.txt" | sed -E 's/[=<>!].*//' | sort -u) \
+        | grep -vE "^($SKIP_DEPS)$" || true)
+    [ -n "$DRIFT" ] && echo "!! daemon-requirements.txt is stale, missing:" $DRIFT
+fi
 
 # ---------- 3. Write daemon .env ----------
 # Generation config defaults = the 3090's CURRENT base-model config (source of truth), so a


### PR DESCRIPTION
## The blocker

The image cannot run the validated identity recipe. The console defaults `faceswap_method` to `facefusion` and the workflow builds node 183 as `AdvancedSwapFaceImage` — only `Facefusion_comfyui` provides it. ReActor is installed, but it selects the target face by **position**, the behaviour that made the seed re-anchor a measured **+0.014** no-op.

Without the node, ComfyUI rejects the prompt and the job fails before generating.

## A clean clone is not enough

The 3090's copy carried **four uncommitted local changes** — the working setup existed on one machine and in no repository. Now patch files in `patches/`:

| file | why it matters |
|---|---|
| `content_filter.py` | one line disabling the NSFW gate — stock, it blocks this content outright |
| `base.py` | imports two helpers from a local shim instead of `comfy_api_nodes.util`, which doesn't exist in the ComfyUI build we pin — **without it the node fails to import** |
| `comfy_compat.py` | that shim; untracked upstream, so it ships as a file |
| `swap_local.py` | uncomments three prints — the only visibility into which face was selected |

The build **asserts** both load-bearing edits landed rather than trusting `git apply` succeeded.

## Models

Bakes the ~900MB the recipe actually uses (`inswapper_128`, `retinaface_10g`, `xseg_1`, `bisenet_resnet_34`, `arcface_w600k_r50`, plus 3MB `scrfd_2.5g` as the node's default detector). The node self-downloads into its **own directory**, which lives in the image rather than on the volume — so otherwise every container start re-fetches them and stalls the first job. GitHub releases, so `download_models.sh` (hf_hub_download only) can't stage them.

## The onnxruntime collision

`start.sh` had:

```bash
pip install --no-cache-dir -q -r "$DAEMON_DIR/requirements.txt" 2>/dev/null || true
```

Two problems. It swallowed every error, so a failed install looked identical to a clean one. And it reinstalled **`onnxruntime` (CPU) over the `onnxruntime-gpu`** that ReActor and FaceFusion need — plus `opencv-python-headless` over `opencv-python` — silently, on every boot, because each pair provides the same module.

Now: deps install from a pinned copy at build time, boot only tops up what's genuinely new, the two colliding packages are skipped explicitly, failures are reported, and a stale pinned copy is flagged at boot.

## Verification

Both stages built locally, not pushed and hoped ([[feedback_test_docker_before_push]]):

```
patches at pin 3e73829   -> PATCHES-OK (both assertions passed)
download loop            -> scrfd_2.5g.onnx 3,295,067 bytes, byte-exact vs the 3090
dep skip/drift logic     -> skips the two colliders, flags a genuinely new dep
```

Closes the two blockers for a working RunPod template. Validation against the 3090's numbers is tracked separately.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct