### PR TITLE
Stop FaceFusion's install.py from replacing the pinned onnxruntime at boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,44 @@ RUN git clone https://github.com/huygiatrng/Facefusion_comfyui.git \
     git -C ComfyUI/custom_nodes/Facefusion_comfyui apply /app/patches/facefusion_comfyui.patch && \
     python3 -c "import ast,sys; ast.parse(open('ComfyUI/custom_nodes/Facefusion_comfyui/content_filter/content_filter.py').read())" && \
     grep -q 'NSFW filter disabled' ComfyUI/custom_nodes/Facefusion_comfyui/content_filter/content_filter.py && \
-    grep -q 'from .comfy_compat import' ComfyUI/custom_nodes/Facefusion_comfyui/facefusion_api/nodes/base.py
+    grep -q 'from .comfy_compat import' ComfyUI/custom_nodes/Facefusion_comfyui/facefusion_api/nodes/base.py && \
+    touch ComfyUI/custom_nodes/Facefusion_comfyui/.install_complete
+
+# The marker above is load-bearing, and its absence cost a whole RunPod job.
+#
+# ComfyUI runs every custom node's install.py at startup. FaceFusion's does:
+#
+#     if pip_show('onnxruntime-gpu').ok and exists('.install_complete'): return
+#     pip uninstall onnx onnxruntime onnxruntime-gpu -y
+#     pip install onnxruntime-gpu          # <- UNPINNED
+#
+# It needs BOTH conditions, and the marker is only ever written at RUNTIME. So a freshly built
+# image always fails the guard on its first container start, uninstalls the pinned 1.20.2, and
+# installs whatever is newest -- currently 1.28.0, a CUDA-13 wheel that cannot load against this
+# image's CUDA 12.4 (libcublasLt.so.13: cannot open shared object file).
+#
+# Nothing crashes. onnxruntime just reports the CUDA provider unavailable and runs the swap on
+# CPU: GPU at 0%, one process at 463%, and every RIFE-interpolated frame swapped in software.
+# The daemon's 300s no-progress watchdog then reports "execution appears stuck" -- so the visible
+# symptom is a hang, several layers away from the cause.
+#
+# It never reproduced on the 3090 because that install has long since written its marker. Fresh
+# containers are exactly the case nobody was testing.
+#
+# Writing the marker at build time makes the guard short-circuit forever, keeping the pin the
+# line above it already paid for.
+
+# Fail the BUILD if the onnxruntime CUDA provider needs libraries this image does not ship.
+# Checked via the provider .so's own NEEDED entries rather than by running it, because the
+# builder has no GPU -- and checked at all because the runtime failure mode is silent.
+RUN python3 -c "\
+import glob, subprocess, sys, onnxruntime;\
+so = glob.glob('/usr/local/lib/python3.11/dist-packages/onnxruntime/capi/libonnxruntime_providers_cuda.so');\
+sys.exit('onnxruntime-gpu missing its CUDA provider') if not so else None;\
+need = [l.split()[1] for l in subprocess.run(['objdump','-p',so[0]],capture_output=True,text=True).stdout.splitlines() if 'NEEDED' in l];\
+bad = [n for n in need if n.endswith('.so.13')];\
+print('onnxruntime', onnxruntime.__version__, '| CUDA provider needs:', ' '.join(n for n in need if 'cublas' in n or 'cudart' in n));\
+sys.exit('CUDA-13 libs required by onnxruntime but image is CUDA 12: %s' % bad) if bad else print('OK: onnxruntime CUDA provider matches this image CUDA major')"
 
 # Bake the FaceFusion models the recipe actually uses (~900MB). The node self-downloads on
 # first use into its OWN directory, which lives in the image rather than on the volume -- so

--- a/start.sh
+++ b/start.sh
@@ -137,6 +137,23 @@ if [ -f "$REACTOR_SFW" ]; then
     echo "Patched ReActor: nsfw_image() returns False (disabled), transformers import stubbed"
 fi
 
+# ---------- 3c. Keep FaceFusion's install.py from replacing the pinned onnxruntime ----------
+# The Dockerfile writes this marker at build time; see the long note there. Re-asserting it here
+# costs nothing and covers the case where the node is updated to a commit that clears or renames
+# it. Without the marker, ComfyUI's startup runs FaceFusion's install.py, which uninstalls the
+# pinned onnxruntime-gpu and installs the newest — a CUDA-13 wheel this CUDA-12.4 image cannot
+# load. The swap then runs on CPU, ~100x slower, with no error anywhere: the only symptom is the
+# daemon's "no progress for 300s" watchdog, which reads as a hang.
+FF_MARKER="/app/ComfyUI/custom_nodes/Facefusion_comfyui/.install_complete"
+if [ -d "$(dirname "$FF_MARKER")" ] && [ ! -f "$FF_MARKER" ]; then
+    touch "$FF_MARKER"
+    echo "WARN: FaceFusion .install_complete was missing — recreated (would have clobbered onnxruntime)"
+fi
+
+# Record what onnxruntime we booted with, so a later change is visible rather than inferred.
+ORT_BOOT=$(pip show onnxruntime-gpu 2>/dev/null | awk '/^Version:/{print $2}')
+echo "onnxruntime-gpu at boot: ${ORT_BOOT:-<not installed>}"
+
 # ---------- 4. Start ComfyUI (background, no auth) ----------
 mkdir -p /workspace/logs
 cd /app/ComfyUI
@@ -167,6 +184,23 @@ if ! curl -sf http://localhost:8188/system_stats > /dev/null 2>&1; then
     echo "ERROR: ComfyUI failed to start within 180s"
     tail -50 /workspace/logs/comfyui.log 2>/dev/null || true
     exit 1
+fi
+
+# ---------- 5b. Did anything replace onnxruntime while ComfyUI was starting? ----------
+# ComfyUI runs every custom node's install.py during startup, and at least one of them (see
+# FaceFusion, above) will pip-install over a pinned dependency given the chance. Comparing the
+# version now against the one recorded before ComfyUI started catches ANY such node, not just
+# the one we know about — and catches it before the first job rather than 300s into one.
+#
+# Loud, not fatal: a mismatched onnxruntime still generates video correctly. It only makes the
+# faceswap fall back to CPU, and a worker that produces slow-but-correct output beats a worker
+# that refuses to boot.
+ORT_NOW=$(pip show onnxruntime-gpu 2>/dev/null | awk '/^Version:/{print $2}')
+if [ -n "$ORT_BOOT" ] && [ "$ORT_NOW" != "$ORT_BOOT" ]; then
+    echo "!! onnxruntime-gpu CHANGED during ComfyUI startup: $ORT_BOOT -> $ORT_NOW"
+    echo "!! A custom node's install.py replaced the pinned build. If the new wheel targets a"
+    echo "!! different CUDA major than this image, the GPU faceswap will silently run on CPU"
+    echo "!! (~100x slower) and surface as the daemon's 'no progress for 300s' watchdog."
 fi
 
 # ---------- 6. Start daemon (foreground) ----------


### PR DESCRIPTION
Closes the failure found by the RunPod template test (#31).

## What happened

A 4090 booted from `wanly22-runpod:latest` claimed a real job and ran the **faceswap on CPU** — GPU at 0%, one process at 463%, no ComfyUI progress for 300s, daemon reporting `execution appears stuck`. Nothing had crashed; the swap was ~100× too slow across every RIFE-interpolated frame.

## Why

ComfyUI runs every custom node's `install.py` at startup. FaceFusion's guard needs **both** `pip show onnxruntime-gpu` to succeed **and** a `.install_complete` marker to exist — and that marker is only ever written at runtime:

```python
if result.returncode == 0 and os.path.exists(marker_file):
    return
pip uninstall onnx onnxruntime onnxruntime-gpu -y
pip install onnxruntime-gpu          # UNPINNED
```

So a freshly built image always fails the guard on first container start and replaces the pinned `onnxruntime-gpu==1.20.2` with the newest — 1.28.0, built against **CUDA 13**. This image is CUDA 12.4, so `libcublasLt.so.13` is missing, `CUDAExecutionProvider` fails to load, and onnxruntime quietly uses CPU.

The Dockerfile pin was never wrong. I confirmed from the CI build log that 1.20.2 was what got installed, and the built image still contains it — the damage happens later, on first boot, which is why the image looks correct on inspection.

**It never reproduced on the 3090**, whose ComfyUI wrote its marker long ago. Fresh containers were the untested case, i.e. every RunPod pod.

## Fix — three layers, because the failure is silent and the symptom is four steps from the cause

1. **Write `.install_complete` at build time** so the guard short-circuits and the pin survives.
2. **Fail the build** if the onnxruntime CUDA provider's `NEEDED` entries name CUDA-13 libraries. Read from the `.so` with `objdump` rather than by running it, since the builder has no GPU.
3. **`start.sh` compares the onnxruntime version before and after ComfyUI startup**, so *any* node doing this is reported at boot instead of 300s into a job. Loud but not fatal — a CPU faceswap still produces correct video, and a slow worker beats a worker that won't boot.

## Verified against the built image

| condition | result |
|---|---|
| onnxruntime 1.20.2 | needs `libcublasLt.so.12` / `libcublas.so.12` / `libcudart.so.12` → assertion **passes** |
| onnxruntime 1.28.0 | needs `...so.13` → assertion **exits 1** |
| boot **without** marker | `[Facefusion_comfyui] Setting up ONNX dependencies...` → becomes **1.28.0** |
| boot **with** marker | `install.py` skipped → stays **1.20.2** |

`bash -n start.sh` clean. Cost of the test run that found this: $0.30.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct