### PR TITLE
Put pip's CUDA libs on the loader path so the faceswap actually uses the GPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,21 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV PIP_ROOT_USER_ACTION=ignore
 
+# onnxruntime finds CUDA/cuDNN through the system loader, and nothing else puts pip's copies on
+# its path. torch does not need this — it preloads its bundled libs at import — so the image
+# looks fine until something that ISN'T torch asks for CUDA.
+#
+# That something is the faceswap. Without this, onnxruntime fails to load its CUDA provider
+# (libcudnn_adv.so.9: cannot open shared object file), reports only CPUExecutionProvider, and
+# FaceFusion runs the swap in software: GPU at 0%, ~100x slower, no error raised. The visible
+# symptom is the daemon's "no progress for 300s" watchdog, four steps removed from the cause.
+#
+# Measured on a 4090 pod, same image, same model, only this variable differing:
+#   unset -> InferenceSession providers: ['CPUExecutionProvider']
+#   set   -> InferenceSession providers: ['CUDAExecutionProvider', 'CPUExecutionProvider']
+ENV NV_PY_LIBS=/usr/local/lib/python3.11/dist-packages/nvidia
+ENV LD_LIBRARY_PATH=${NV_PY_LIBS}/cudnn/lib:${NV_PY_LIBS}/cublas/lib:${NV_PY_LIBS}/cuda_runtime/lib:${NV_PY_LIBS}/curand/lib:${NV_PY_LIBS}/cufft/lib:${NV_PY_LIBS}/cusparse/lib:${NV_PY_LIBS}/cusolver/lib:${NV_PY_LIBS}/nvjitlink/lib
+
 # System deps + Python 3.11 via deadsnakes PPA
 RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common && \
@@ -121,17 +136,18 @@ RUN git clone https://github.com/huygiatrng/Facefusion_comfyui.git \
 # Writing the marker at build time makes the guard short-circuit forever, keeping the pin the
 # line above it already paid for.
 
-# Fail the BUILD if the onnxruntime CUDA provider needs libraries this image does not ship.
-# Checked via the provider .so's own NEEDED entries rather than by running it, because the
-# builder has no GPU -- and checked at all because the runtime failure mode is silent.
-RUN python3 -c "\
-import glob, subprocess, sys, onnxruntime;\
-so = glob.glob('/usr/local/lib/python3.11/dist-packages/onnxruntime/capi/libonnxruntime_providers_cuda.so');\
-sys.exit('onnxruntime-gpu missing its CUDA provider') if not so else None;\
-need = [l.split()[1] for l in subprocess.run(['objdump','-p',so[0]],capture_output=True,text=True).stdout.splitlines() if 'NEEDED' in l];\
-bad = [n for n in need if n.endswith('.so.13')];\
-print('onnxruntime', onnxruntime.__version__, '| CUDA provider needs:', ' '.join(n for n in need if 'cublas' in n or 'cudart' in n));\
-sys.exit('CUDA-13 libs required by onnxruntime but image is CUDA 12: %s' % bad) if bad else print('OK: onnxruntime CUDA provider matches this image CUDA major')"
+# Fail the BUILD if the onnxruntime CUDA provider cannot resolve its libraries.
+#
+# ldd, not a version check: the two ways this has actually broken were a CUDA-major mismatch
+# (a wheel wanting libcublasLt.so.13 on a CUDA-12 image) and a path problem (cuDNN present in
+# site-packages but not on LD_LIBRARY_PATH). A version assertion catches only the first. "Every
+# NEEDED entry resolves" catches both, plus whatever the third one turns out to be.
+#
+# ldd resolves against this image's LD_LIBRARY_PATH, set above -- which is the same loader the
+# runtime uses, so a pass here means a pass in the container. No GPU required, which matters
+# because the CI builder has none.
+COPY assert_onnx_cuda.py /app/assert_onnx_cuda.py
+RUN python3 /app/assert_onnx_cuda.py
 
 # Bake the FaceFusion models the recipe actually uses (~900MB). The node self-downloads on
 # first use into its OWN directory, which lives in the image rather than on the volume -- so

--- a/assert_onnx_cuda.py
+++ b/assert_onnx_cuda.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Fail the build if onnxruntime's CUDA provider cannot resolve its shared libraries.
+
+This exists because the runtime failure is silent. onnxruntime does not raise when its CUDA
+provider fails to load — it logs a warning, drops to CPUExecutionProvider, and carries on. The
+faceswap then runs in software at roughly 1/100th the speed, so what actually reaches you is the
+daemon's "no progress from ComfyUI for 300s" watchdog: a hang, four steps from the cause.
+
+Two real failures, both shipped in images that looked correct on inspection:
+
+  1. A custom node's install.py replaced the pinned onnxruntime-gpu with a CUDA-13 wheel on this
+     CUDA-12.4 image -> libcublasLt.so.13 missing.
+  2. cuDNN was present in site-packages but not on LD_LIBRARY_PATH -> libcudnn_adv.so.9 missing.
+
+A version assertion catches only the first. Checking that every NEEDED entry resolves catches
+both, and whatever the third one turns out to be.
+
+ldd is used rather than loading the provider, because the CI builder has no GPU. It resolves
+against the same LD_LIBRARY_PATH the container will use, so a pass here means a pass at runtime.
+"""
+import glob
+import subprocess
+import sys
+
+PROVIDER_GLOB = "/usr/local/lib/python3.*/dist-packages/onnxruntime/capi/libonnxruntime_providers_cuda.so"
+
+
+def main() -> int:
+    matches = glob.glob(PROVIDER_GLOB)
+    if not matches:
+        print("FAIL: onnxruntime-gpu is installed without its CUDA provider .so", file=sys.stderr)
+        return 1
+    provider = matches[0]
+
+    import onnxruntime
+
+    ldd = subprocess.run(["ldd", provider], capture_output=True, text=True).stdout
+    missing = [line.split("=>")[0].strip() for line in ldd.splitlines() if "not found" in line]
+
+    cuda_deps = sorted(
+        {
+            line.split("=>")[0].strip()
+            for line in ldd.splitlines()
+            if any(k in line for k in ("cublas", "cudart", "cudnn"))
+        }
+    )
+    print(f"onnxruntime {onnxruntime.__version__}")
+    print(f"  CUDA deps: {' '.join(cuda_deps)}")
+
+    if missing:
+        print(
+            "FAIL: onnxruntime CUDA provider cannot resolve:\n  "
+            + "\n  ".join(missing)
+            + "\n\nThe container would fall back to CPUExecutionProvider silently and the "
+            "faceswap would run ~100x slower.\nEither the wheel targets a different CUDA major "
+            "than this image, or LD_LIBRARY_PATH is missing the\npip-installed nvidia/*/lib "
+            "directories.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("OK: every CUDA provider dependency resolves")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #32, found by re-testing on a fresh pod. **#32 worked and was not sufficient.**

The second pod booted with `onnxruntime-gpu 1.20.2` intact and `install.py` skipped — the marker fix held. The swap still ran on CPU:

```
Failed to load library libonnxruntime_providers_cuda.so
  with error: libcudnn_adv.so.9: cannot open shared object file
```

`LD_LIBRARY_PATH` was empty. All nine cuDNN libraries ship inside `site-packages/nvidia/cudnn/lib`; nothing put that directory on the loader path. **torch doesn't care** — it preloads its bundled CUDA libs at import — so the image looks healthy right up until something that isn't torch asks for CUDA. That something is the faceswap.

Measured on the pod, same image, same model, only the variable differing:

| | providers actually used |
|---|---|
| unset | `['CPUExecutionProvider']` |
| set | `['CUDAExecutionProvider', 'CPUExecutionProvider']` |

**So GPU faceswap has never worked in this container.** The version clobber in #32 was real and worth fixing, but it was not the whole story.

## Also: the assertion from #32 was too weak

It only looked for CUDA-13 sonames, so it would have **passed** this bug — and did, in the build that produced the pod I just tested. Replaced with `assert_onnx_cuda.py`, which requires *every* `NEEDED` entry of the provider to resolve. That covers a CUDA-major mismatch, a path problem, and whatever the third variant turns out to be. `ldd` rather than loading the provider, because the CI builder has no GPU; it resolves against the same `LD_LIBRARY_PATH` the container will use, so a pass here means a pass at runtime.

## Verified against the currently shipped image

| condition | result |
|---|---|
| without `LD_LIBRARY_PATH` | 8 unresolved `libcudnn_*.so.9` entries → **exit 1** |
| with `LD_LIBRARY_PATH` | all 11 CUDA deps resolve → **exit 0** |

Test cost so far: $0.89 across two pods.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct