### PR TITLE
Make a slow boot distinguishable from a wedged one

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -26,7 +26,7 @@ pip install --no-cache-dir -q "huggingface_hub>=0.34" hf_xet || true
 echo "=== Downloading models to ${MODELS_DIR} ==="
 
 MODELS_DIR="$MODELS_DIR" INSIGHTFACE_DIR="$INSIGHTFACE_DIR" python3 - <<'PY'
-import os, shutil
+import os, shutil, time
 from huggingface_hub import hf_hub_download
 
 M = os.environ["MODELS_DIR"]
@@ -71,7 +71,8 @@ JOBS = [
           f"{IF}/inswapper_128.onnx", "dataset", False),
 ]
 
-for repo, path, dst, repo_type, critical in JOBS:
+total = len(JOBS)
+for idx, (repo, path, dst, repo_type, critical) in enumerate(JOBS, 1):
     name = os.path.basename(dst)
     ctrl = dst + ".aria2"
     if os.path.exists(ctrl):                      # leftover aria2 partial -> redownload
@@ -88,14 +89,23 @@ for repo, path, dst, repo_type, critical in JOBS:
     # copies of a 27GB weight (matters on a fresh pod with a modest volume).
     stage = os.path.join(os.path.dirname(dst), ".hfstage")
     os.makedirs(stage, exist_ok=True)
+    # Announce BEFORE downloading. hf_hub_download prints nothing while a 13GB weight comes
+    # down, so the previous "OK <name>" on completion meant minutes of total silence that were
+    # indistinguishable from a hang -- which is precisely how a boot gets misread as stuck.
+    print(f"[{idx}/{total}] downloading {name} from {repo}/{path} ...", flush=True)
+    started = time.monotonic()
     try:
         src = hf_hub_download(repo_id=repo, filename=path, repo_type=repo_type, local_dir=stage)
         os.replace(src, dst)                      # same filesystem -> instant, no copy
-        print(f"OK {name} ({os.path.getsize(dst)//1_000_000} MB)")
+        mb = os.path.getsize(dst) // 1_000_000
+        secs = max(1, int(time.monotonic() - started))
+        # Rate is the useful number when deciding whether a slow boot is progressing or wedged.
+        print(f"[{idx}/{total}] OK {name} ({mb} MB in {secs}s, {mb // secs} MB/s)", flush=True)
     except Exception as e:
         if critical:
             raise
-        print(f"WARN: optional {name} failed ({type(e).__name__}); continuing boot")
+        print(f"[{idx}/{total}] WARN: optional {name} failed ({type(e).__name__}); continuing boot",
+              flush=True)
     finally:
         shutil.rmtree(stage, ignore_errors=True)
 

--- a/start.sh
+++ b/start.sh
@@ -15,7 +15,12 @@ set -e
 # replaces this shell and stays the container's main process — a pipeline would leave the shell
 # alive as PID 1 and change how SIGTERM reaches the daemon on pod stop.
 mkdir -p /workspace/logs
-exec > >(tee -a /workspace/logs/daemon.log) 2>&1
+# Timestamp every line. Without it there is no way to tell a boot that is slow from one that is
+# wedged: both look like a log that has stopped moving. awk rather than `ts` because moreutils is
+# not in the image, and fflush keeps it streaming rather than block-buffering into RunPod's
+# console. Still process substitution, not a pipeline, so the exec at the end of this script
+# still replaces the shell.
+exec > >(awk '{ print strftime("%H:%M:%S"), $0; fflush() }' | tee -a /workspace/logs/daemon.log) 2>&1
 
 echo "=== Wanly RunPod Worker Starting ==="
 echo "(this log is also at /workspace/logs/daemon.log)"
@@ -32,8 +37,12 @@ if [ -n "${PUBLIC_KEY:-}" ]; then
 fi
 
 # ---------- 1. Download models (skips existing) ----------
+# The slowest phase by far on a cold pod -- roughly 37GB -- and the one most likely to be
+# mistaken for a hang, so it announces each file before starting rather than only on completion.
+echo "PHASE 1/5: staging models (cold pod downloads ~37GB; this is the slow part)"
 /app/download_models.sh
 
+echo "PHASE 2/5: daemon code"
 # ---------- 2. Clone or update daemon ----------
 DAEMON_DIR="/app/wanly-gpu-daemon"
 DAEMON_REPO="https://github.com/DavidJBarnes/wanly-gpu-daemon.git"
@@ -89,6 +98,7 @@ if [ -f /app/daemon-requirements.txt ] && [ -f "$DAEMON_DIR/requirements.txt" ];
     [ -n "$DRIFT" ] && echo "!! daemon-requirements.txt is stale, missing:" $DRIFT
 fi
 
+echo "PHASE 3/5: config and custom-node patches"
 # ---------- 3. Write daemon .env ----------
 # Parity with the 3090 is checked by diffing this block against that box's .env, NOT by memory.
 # It drifted once before (DaSiWa + lightx2v 0 vs base + lightx2v 2.0) and cost a full day of
@@ -180,7 +190,7 @@ python3 main.py --listen 0.0.0.0 --port 8188 \
     --cache-none \
     > /workspace/logs/comfyui.log 2>&1 &
 COMFYUI_PID=$!
-echo "ComfyUI started (PID $COMFYUI_PID)"
+echo "PHASE 4/5: ComfyUI started (PID $COMFYUI_PID), waiting for it to answer"
 
 # ---------- 5. Wait for ComfyUI ready ----------
 echo "Waiting for ComfyUI..."
@@ -221,6 +231,6 @@ if [ -n "$ORT_BOOT" ] && [ "$ORT_NOW" != "$ORT_BOOT" ]; then
 fi
 
 # ---------- 6. Start daemon (foreground) ----------
-echo "Starting wanly-gpu-daemon..."
+echo "PHASE 5/5: starting wanly-gpu-daemon (registers as a worker once models validate)"
 cd "$DAEMON_DIR"
 exec python3 -m daemon.main


### PR DESCRIPTION
A pod sat for eighteen minutes looking identical to a healthy one staging models. The only way to tell was opening the RunPod console — and the log there did not say much either.

**Every line is timestamped.** Without it there is no way to tell a boot that is slow from one that has stopped: both look like a log that is not moving. `awk` rather than `ts` because moreutils is not in the image, with `fflush` so it streams into RunPod's console rather than block-buffering. Still process substitution rather than a pipeline, so the `exec` at the end still replaces the shell.

**Model downloads announce before they start.** `hf_hub_download` prints nothing while a 13 GB weight comes down, so `OK <name>` on completion meant several minutes of total silence per file — the exact appearance of a hang, during the phase most likely to be slow:

```
[3/9] downloading wan2.2_i2v_high_noise_14B_fp8_scaled from Comfy-Org/... 
[3/9] OK wan2.2_i2v_high_noise_14B_fp8_scaled (13310 MB in 214s, 62 MB/s)
```

The rate is the useful number: it tells you whether a slow boot is progressing or stalled.

**Five numbered phase markers**, so the last line printed says how far it got rather than leaving you to infer it from whichever incidental message came last.

## Verification

`bash -n` on both scripts, and the embedded Python in `download_models.sh` compiled separately — a syntax error there would otherwise only surface at boot, on a pod that is already billing.

Not yet run on a live pod. Pushing to main triggers the image build, so this is worth a real boot before relying on it.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct