### PR TITLE
Restore the build toolchain: insightface compiles and the image had no gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,22 @@ RUN pip install --no-cache-dir -r /app/engine-requirements.txt
 # start.sh compares this against the daemon's own requirements.txt at boot and
 # warns loudly when they drift. This only has to cover what the image installs
 # ahead of time; anything added since is installed at boot.
+#
+# insightface ships no wheel and compiles C extensions (face3d/mesh/cython), so this needs a
+# toolchain — dropping build-essential when this image was rewritten for LTX is what failed
+# the first CI build with "x86_64-linux-gnu-gcc: No such file or directory".
+#
+# Installed and purged in ONE layer so the runtime image does not carry a compiler. Separate
+# RUN steps would leave it in the layer below regardless of a later apt-get remove.
+#
+# insightface is not optional here: identity scoring runs on every finished render, LTX
+# included, and it is what produces the identity chips the console shows.
 COPY daemon-requirements.txt /app/daemon-requirements.txt
-RUN pip install --no-cache-dir -r /app/daemon-requirements.txt
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential python3-dev \
+ && pip install --no-cache-dir -r /app/daemon-requirements.txt \
+ && apt-get purge -y --auto-remove build-essential python3-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 # Models are bind-mounted, never baked: the LTX-2.3 set alone is ~126 GB.
 ENV COMFY_PORT=8188 \


### PR DESCRIPTION
The first LTX image build failed, in CI and on 3090.zero, identically:

```
x86_64-linux-gnu-gcc: No such file or directory
ERROR: Failed building wheel for insightface
```

`insightface` ships no wheel and compiles C extensions (`face3d/mesh/cython`). Rewriting this image for LTX trimmed the apt list, and `build-essential` went with the WAN stack it appeared to belong to.

**It doesn't belong to WAN.** insightface backs identity scoring, which runs on every finished render — LTX included — and produces the identity chips the console shows. Removing it was never on the table; removing its compiler happened by accident.

Installed and purged in **one layer**, so the runtime image doesn't carry a compiler. Separate `RUN` steps would leave it in the layer below regardless of a later `apt-get remove`.

Two independent builds reproducing the same failure is the useful part — it was the Dockerfile, not the machine.

Refs #41