### PR TITLE
A missing keyframe-server must not fail a render

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -546,15 +546,29 @@ def free_the_gpu() -> float:
     Paying the reload only when memory is actually tight keeps the fast path
     free and pays the cost exactly when it buys something.
     """
+    # keyframe-server is OPTIONAL. If it is not running there is no GPU for it to free, and
+    # that is success, not failure — this used to raise, so an absent collaborator failed a
+    # render that had already been claimed. Connection refused therefore falls through to
+    # measuring the card directly.
+    #
+    # A server that IS up and refuses to yield stays a hard failure: that is a real conflict
+    # over the GPU, and proceeding into a model load would OOM instead.
+    free = None
     try:
         r = requests.post(f"{KEYFRAME_URL}/free", timeout=180)
         if r.status_code != 200:
-            # A 404 means keyframe-server predates the /free endpoint. Say so
-            # plainly rather than letting LTX die in a model load.
             raise RuntimeError(f"keyframe-server /free -> {r.status_code} {r.text[:200]}")
         free = float(r.json().get("vram_free_gb", 0.0))
-    except requests.RequestException as e:
-        raise RuntimeError(f"keyframe-server unreachable at {KEYFRAME_URL}: {e}")
+    except requests.ConnectionError:
+        print(f"[gpu] keyframe-server not running at {KEYFRAME_URL} — nothing to free",
+              flush=True)
+    except requests.Timeout as e:
+        # Up but not answering. Distinct from absent, and worth failing on: something holds
+        # the card and is not letting go.
+        raise RuntimeError(f"keyframe-server timed out yielding the GPU: {e}")
+
+    if free is None:
+        free = comfy_vram_free_gb()
 
     if free >= MIN_FREE_GB:
         return free


### PR DESCRIPTION
Reported live — a claimed segment died with:

```
RuntimeError: keyframe-server unreachable at http://172.17.0.1:8189: Connection refused
```

Nothing was wrong with the render. keyframe-server simply wasn't running, and the engine treated that as fatal.

**If it isn't running there's no GPU for it to free — that's success, not failure.** Turning "an optional collaborator is absent" into "your render failed" is wrong on its own terms, and expensive in practice: it surfaces on a segment that has *already been claimed*, after the queue has committed to it.

## Behaviour now

| keyframe-server | result |
|---|---|
| absent (connection refused) | **no-op** — proceeds on the card's own free VRAM |
| up and yields | unchanged |
| up, refuses (500) | still a hard failure |
| up, times out | **newly distinguished** — also fails |

A server that's up and won't yield is a real conflict over the GPU, and proceeding into a model load would OOM instead. A timeout means something holds the card and isn't letting go — previously lumped in with "unreachable".

## Verification

This repo has no test suite, so I exercised all four cases against the extracted function with the HTTP layer stubbed. Output in the commit message.

## Scope

This is the **first half** of #44. Removing keyframe-server as a dependency altogether is the second, and is no longer urgent now that its absence is harmless.

Refs #44