### PR TITLE
fix: stage model downloads on the volume, not the container overlay

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -81,24 +81,28 @@ _fetch() {
     mkdir -p "$dest_dir"
     echo "  fetching $name from $repo"
     t0=$(date +%s)
-    # The LIBRARY, not the `hf` CLI. ComfyUI's requirements install huggingface_hub, but the
-    # `hf` entry point only exists in newer releases -- so a pod could reach here and die on
-    # "hf: command not found", after which the fallback `pip install huggingface_hub[cli]` is
-    # a no-op because the requirement is already satisfied by an older version.
-    # hf_hub_download has been stable across all of them.
+    # Staged INSIDE $MODELS, never /tmp. On the 3090 /tmp is a large host disk; on a pod it is
+    # the container overlay, which is 30-40 GB against a 43 GB checkpoint -- so staging there
+    # cannot finish however big the volume is. The first real pod died exactly this way, at
+    # 28 GB of 43 with the 60 GB volume sitting empty beside it.
     #
-    # Always staged in /tmp and moved: a repo path lands nested, the stored name can differ
-    # from the repo's, and a partial download must never be visible under the final name --
-    # which is the silent failure the truncation check below exists to catch.
-    rm -rf /tmp/hfdl
-    python3 - "$repo" "${path:-$name}" <<'PYEOF' || return 1
+    # Same filesystem as the destination, so the move below is a rename rather than a second
+    # 43 GB copy.
+    #
+    # Staged and moved rather than written in place because a repo path lands nested, the
+    # stored name can differ from the repo's, and a partial download must never be visible
+    # under the final name -- the silent failure the truncation check below exists to catch.
+    local stage="$MODELS/.staging"
+    rm -rf "$stage"
+    mkdir -p "$stage"
+    python3 - "$repo" "${path:-$name}" "$stage" <<'PYEOF' || return 1
 import sys
 from huggingface_hub import hf_hub_download
-repo, filename = sys.argv[1], sys.argv[2]
-hf_hub_download(repo_id=repo, filename=filename, local_dir="/tmp/hfdl")
+repo, filename, stage = sys.argv[1], sys.argv[2], sys.argv[3]
+hf_hub_download(repo_id=repo, filename=filename, local_dir=stage)
 PYEOF
-    mv -f "/tmp/hfdl/${path:-$name}" "$dest_dir/$name" || return 1
-    rm -rf /tmp/hfdl
+    mv -f "$stage/${path:-$name}" "$dest_dir/$name" || return 1
+    rm -rf "$stage"
     _report "$dest_dir/$name" "$t0"
 }
 

--- a/start.sh
+++ b/start.sh
@@ -17,7 +17,16 @@ set -e
 mkdir -p /workspace/logs
 # Timestamp every line. Without it there is no way to tell a boot that is slow from one that is
 # wedged: both look like a log that has stopped moving.
-exec > >(awk '{ print strftime("%H:%M:%S"), $0; fflush() }' | tee -a /workspace/logs/daemon.log) 2>&1
+#
+# stdbuf on both stages is defensive, not a proven fix. On the first real pod (2026-09-01)
+# daemon.log sat at 0 bytes and the RunPod console showed nothing after the NVIDIA banner for
+# twelve minutes while the boot was in fact running normally — the exact ambiguity this line
+# exists to remove. The cause is NOT established: tee block-buffering was the obvious
+# suspect, and measuring it locally disproved that — both pipelines flush a line within a
+# second. So this removes buffering as a possibility rather than fixing a known bug, and the
+# real cause is still open. Do not treat an empty log as explained.
+exec > >(stdbuf -oL awk '{ print strftime("%H:%M:%S"), $0; fflush() }' \
+         | stdbuf -oL tee -a /workspace/logs/daemon.log) 2>&1
 
 echo "=== Wanly GPU Worker (LTX 2.3) ==="
 echo "image build: ${GIT_SHA:-unknown}"


### PR DESCRIPTION
The first real pod (2026-09-01) died at **28 GB of a 43 GB checkpoint with its 60 GB volume sitting empty beside it**, because the fetch staged through `/tmp/hfdl`.

On the 3090 `/tmp` is a large host disk. On a pod it is the **container overlay** — 30 GB — so staging there cannot finish however large the volume is. The volume was also undersized (wanly-api#226), but this would have failed at 40 GB of overlay too.

Staging now happens in `$MODELS/.staging`, which additionally makes the final move a rename rather than a second 43 GB copy across filesystems.

## The log, honestly

`stdbuf` is added to the log pipeline. **This is defensive, not a fix.**

On that pod `daemon.log` sat at 0 bytes and the console showed nothing after the NVIDIA banner for twelve minutes — while the boot was running normally the whole time. That is precisely the ambiguity the timestamping line exists to remove.

`tee` block-buffering was the obvious suspect, and measuring it locally **disproved it**: both the old and new pipelines flush a line within a second. So this removes buffering as a possibility rather than fixing a known bug. The comment says so, because an empty log that looks explained is worse than one that looks unexplained.

Verified against the 3090's real tree: still fetches nothing, still `models OK`, no `.staging` left behind.

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG