### PR TITLE
chore: put new issues on the Wanly22 board automatically

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,30 @@
+name: Add issues to Wanly22
+
+# Every issue opened in this repo lands on the board automatically.
+#
+# Written as an Action rather than configured in the project UI because the built-in
+# "Auto-add to project" workflow cannot be created through the API — GraphQL exposes only
+# deleteProjectV2Workflow — so a UI-configured one is invisible to review, cannot be diffed,
+# and has to be re-created by hand per repository. This file is the same behaviour, in the
+# repo it applies to.
+#
+# ISSUES ONLY, deliberately: a PR belongs to the board through its issue's "Linked pull
+# requests" field, not as an item of its own.
+#
+# Needs a token with `project` scope — GITHUB_TOKEN cannot write to a USER-owned project,
+# which is what Wanly22 is. Store a classic PAT (scopes: project, repo) as the repository or
+# organisation secret ADD_TO_PROJECT_PAT. Without it this job fails loudly on the first issue
+# rather than silently not adding anything, which is the failure mode worth avoiding.
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/DavidJBarnes/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Tickets have been filed as repo issues and gone unseen, because [the board](https://github.com/users/DavidJBarnes/projects/2) is where they are read and nothing was putting them there.

An Action rather than the project's built-in **Auto-add to project** workflow, because that one **cannot be created through the API** — GraphQL exposes only `deleteProjectV2Workflow`. A UI-configured workflow is invisible to review, undiffable, and has to be re-created by hand per repository. This file is the same behaviour, in the repo it applies to.

**Issues only**, deliberately: a PR reaches the board through its issue's *Linked pull requests* field, not as its own item.

## One manual step

Needs a classic PAT with `project` + `repo` scope stored as the secret `ADD_TO_PROJECT_PAT` (repo or org level). `GITHUB_TOKEN` cannot write to a **user-owned** project, which Wanly22 is.

Without the secret the job fails loudly on the first issue rather than quietly adding nothing — a silent automation is worse than none, because it looks like it works.

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG