### PR TITLE
fix: torch was built for CUDA 13, so the image only ran on driver >= 580

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,15 @@ WORKDIR /app
 # pinning it would either fail the build or drag torch backwards to match. If a
 # node turns out to need it, add it explicitly against whatever torch resolves
 # to rather than letting the resolver choose for both.
-RUN pip install --no-cache-dir "torch==2.12.1" "torchvision==0.27.1"
+# CUDA 12.8 wheels, PINNED TO THE INDEX. Plain `pip install torch==2.12.1` resolves to
+# 2.12.1+cu130, which requires an NVIDIA driver >= 580. The 3090 has 580.95 and worked; a
+# RunPod 4090 had 570.195 and ComfyUI died on import with "The NVIDIA driver on your system
+# is too old (found version 12080)", which failed the boot and put the pod in a restart loop.
+#
+# RunPod host drivers vary and cannot be chosen, so the image must run on the older one.
+# cu128 runs on both.
+RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cu128 \
+    "torch==2.12.1" "torchvision==0.27.1"
 
 ARG COMFYUI_COMMIT=master
 RUN git clone https://github.com/comfyanonymous/ComfyUI.git /app/ComfyUI \

--- a/start.sh
+++ b/start.sh
@@ -145,6 +145,19 @@ echo "Daemon config:"
 sed -E 's/^(.*(KEY|TOKEN|SECRET|PASSWORD))=.+$/\1=<redacted>/' "$DAEMON_DIR/.env" | sed 's/^/  /'
 
 # ---------- 4. ComfyUI ----------
+# Fail LOUDLY on a driver too old for this torch build, rather than letting ComfyUI die on
+# import with its output going nowhere. A pod spent an hour restart-looping on exactly this:
+# the container died 16s into phase 3 with an empty comfyui.log, and the reason was only
+# visible by running ComfyUI by hand.
+if ! python3 -c "import torch; assert torch.cuda.is_available()" 2>/dev/null; then
+    echo "!! FATAL: torch cannot initialise CUDA on this host."
+    echo "!! torch: $(python3 -c 'import torch;print(torch.__version__, torch.version.cuda)' 2>&1 | tail -1)"
+    echo "!! driver: $(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1)"
+    echo "!! A cu130 build needs driver >= 580. This image pins cu128, which runs on 550+."
+    echo "!! If the driver is older than that, this host cannot run the image — pick another."
+    exit 1
+fi
+
 echo "PHASE 3/6: starting ComfyUI on :${COMFY_PORT:-8188}"
 cd /app/ComfyUI
 python3 main.py --listen 127.0.0.1 --port "${COMFY_PORT:-8188}" \


### PR DESCRIPTION
A RunPod 4090 restart-looped for an hour. ComfyUI died on import:

```
RuntimeError: The NVIDIA driver on your system is too old (found version 12080)
```

`pip install torch==2.12.1` resolves to **2.12.1+cu130**, which needs driver ≥ 580.

| host | driver | result |
|---|---|---|
| 3090.zero | 580.95.05 | works |
| RunPod 4090 | 570.195.03 | CUDA never initialises |

So the image has only ever run on hosts that happened to have a new enough driver. **RunPod host drivers vary and cannot be chosen**, so the image must run on the older one — torch and torchvision now come from the **cu128** index explicitly, which both drivers support.

Pinning the version without pinning the *index* is what hid this: the same line kept working on the one box it was tested on.

## Plus a preflight, because this failure was invisible

The container died 16 s into phase 3 with an **empty comfyui.log**, nothing in daemon.log, and the cause was only found by running ComfyUI by hand inside the pod between restarts. `start.sh` now checks `torch.cuda.is_available()` first and prints the torch build, the driver version, and what it requires — every cycle, instead of silence.

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG