### PR TITLE
feat: engine applies a per-render img_compression

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -196,6 +196,9 @@ class JobRequest(BaseModel):
     seed: int | None = None
     # Steers the graph's negative encoder.
     negative_prompt: str | None = None
+    # Video CRF applied to the conditioning frame before it anchors the render. None leaves
+    # the workflow's own value alone; 0 is meaningful and bypasses the encode entirely.
+    img_compression: int | None = Field(default=None, ge=0, le=51)
     num_inference_steps: int | None = Field(default=None, ge=1, le=50)
     # Steps per pass. None leaves that stage on the schedule the graph ships.
     #
@@ -716,6 +719,7 @@ def run_job(job: Job):
                 char_lora=(lora.name if lora else None),
                 char_s1=(lora.at(1) if lora else 0.8),
                 char_s2=(lora.at(2) if lora else 1.5),
+                img_compression=job.req.img_compression,
             )
             if job.req.num_frames:
                 comfy.set_frames(graph, job.req.num_frames)

--- a/engine/recipe.py
+++ b/engine/recipe.py
@@ -31,7 +31,7 @@ RECIPE_WORKFLOW = "ltx23_recipe.api.json"
 def resolve(graph: dict, image_name: str, width: int, height: int, *,
             prompt: str, negative: str | None = None, checkpoint: str | None = None,
             char_lora: str | None = None, char_s1: float = 0.8, char_s2: float = 1.5,
-            content_lora: str | None = None) -> dict:
+            content_lora: str | None = None, img_compression: int | None = None) -> dict:
     """Patch the validated graph with this render's configuration.
 
     Values only, never topology — the graph template is the validated recipe and this moves
@@ -48,6 +48,13 @@ def resolve(graph: dict, image_name: str, width: int, height: int, *,
     g["167"]["inputs"]["image"] = image_name
     g["292"]["inputs"]["value"] = int(width)
     g["293"]["inputs"]["value"] = int(height)
+    # Conditioning-frame CRF. `is not None` rather than truthiness: 0 is a real setting that
+    # bypasses the encode, and `if img_compression:` would silently ignore it.
+    if img_compression is not None:
+        for v in g.values():
+            if isinstance(v, dict) and v.get("class_type") == "LTXVPreprocess":
+                v["inputs"]["img_compression"] = int(img_compression)
+
     g["121"]["inputs"]["text"] = prompt
     if negative:
         g["110"]["inputs"]["text"] = negative


### PR DESCRIPTION
The value the API resolves (wanly-api#235) has to reach the graph. `resolve()` now takes it and patches every `LTXVPreprocess` node; absent, the workflow's own value stands.

`is not None`, not truthiness: **0 is a real setting** that bypasses the conditioning-frame encode, and `if img_compression:` would ignore exactly the request asking for it.

Verified against the real workflow:

```
no value passed   -> [18]   workflow default untouched
img_compression=4 -> [4]
img_compression=0 -> [0]    honoured, not treated as unset
hash changes with it: True
```

That last line matters — a changed CRF moves `graph_sha256`, so it shows up in the regression trail instead of silently altering renders that hash identically.

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG