### PR TITLE
engine: content LoRA strength is per stage, not one hardcoded 0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+# This repo had no tests and no test CI — only the image build. It contains the recipe
+# resolver, which CLAUDE.md calls load-bearing: the validated DR34 i2v graph is patched
+# VALUES ONLY, never topology, and a change to what resolve() emits is a change to every
+# render that has ever been validated. That is worth more than a build check.
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # pytest alone. The resolver tests are pure — they load the workflow JSON and compare
+      # the patched graph. Nothing here touches torch, ComfyUI or a GPU, and it should stay
+      # that way: a test that needs the real stack belongs on a GPU runner, not in CI.
+      - name: Install test dependencies
+        run: pip install pytest
+
+      - name: Test
+        run: python -m pytest tests/ -q
+
+      # Undefined names are the failure class that has cost this project the most: three
+      # production 500s in a month, each a name that imported fine and blew up at request
+      # time. Same guard as wanly-api and wanly-gpu-daemon.
+      - name: No undefined names
+        run: |
+          pip install "ruff>=0.5"
+          python -m ruff check --select F821 --output-format concise engine/

--- a/engine/app.py
+++ b/engine/app.py
@@ -199,6 +199,18 @@ class JobRequest(BaseModel):
     # Video CRF applied to the conditioning frame before it anchors the render. None leaves
     # the workflow's own value alone; 0 is meaningful and bypasses the encode entirely.
     img_compression: int | None = Field(default=None, ge=0, le=51)
+    # The pose's content LoRA -- motion and act -- chained ahead of the character LoRA on
+    # both stage branches. Named explicitly rather than reusing `loras[0]`, which the recipe
+    # path already spends on the CHARACTER LoRA; one list carrying two different roles by
+    # index is how the wrong one gets loaded.
+    #
+    # None and "none" both mean "render without one", which is what every pose does today.
+    content_lora: str | None = None
+    # Per stage, and bounded at 2.0 to match Lora above. Defaults are 0.6/0.6 -- exactly what
+    # resolve() hardcoded for both stages before this was configurable -- so a request that
+    # omits them renders the graph that was validated.
+    content_s1: float = Field(default=0.6, ge=0.0, le=2.0)
+    content_s2: float = Field(default=0.6, ge=0.0, le=2.0)
     num_inference_steps: int | None = Field(default=None, ge=1, le=50)
     # Steps per pass. None leaves that stage on the schedule the graph ships.
     #
@@ -719,6 +731,9 @@ def run_job(job: Job):
                 char_lora=(lora.name if lora else None),
                 char_s1=(lora.at(1) if lora else 0.8),
                 char_s2=(lora.at(2) if lora else 1.5),
+                content_lora=job.req.content_lora,
+                content_s1=job.req.content_s1,
+                content_s2=job.req.content_s2,
                 img_compression=job.req.img_compression,
             )
             if job.req.num_frames:

--- a/engine/recipe.py
+++ b/engine/recipe.py
@@ -31,7 +31,8 @@ RECIPE_WORKFLOW = "ltx23_recipe.api.json"
 def resolve(graph: dict, image_name: str, width: int, height: int, *,
             prompt: str, negative: str | None = None, checkpoint: str | None = None,
             char_lora: str | None = None, char_s1: float = 0.8, char_s2: float = 1.5,
-            content_lora: str | None = None, img_compression: int | None = None) -> dict:
+            content_lora: str | None = None, content_s1: float = 0.6, content_s2: float = 0.6,
+            img_compression: int | None = None) -> dict:
     """Patch the validated graph with this render's configuration.
 
     Values only, never topology — the graph template is the validated recipe and this moves
@@ -72,13 +73,22 @@ def resolve(graph: dict, image_name: str, width: int, height: int, *,
     # for a shot where the start frame already carries the identity.
     char_name = (char_lora or "").strip()
     want_char = char_name.lower() not in ("", "none")
-    for tag, (branch, strength) in {"1": ("337", s1), "2": ("372", s2)}.items():
+    # Per stage, like the character strengths beside them. This was 0.6 hardcoded for BOTH
+    # stages, which is a configuration rather than a default -- stage 1 generates at half
+    # size from noise and stage 2 refines the 2x-upscaled latent, so one number for both is
+    # a different setup, not a simpler one. 0.6/0.6 remains the default so a caller that
+    # says nothing gets exactly the graph that was validated.
+    c1 = float(content_s1)
+    c2 = float(content_s2)
+    for tag, (branch, strength, cstrength) in {
+        "1": ("337", s1, c1), "2": ("372", s2, c2),
+    }.items():
         prev = ["301", 0]
         if has_content:
             cid = f"960{tag}"
             name = content if content.endswith(".safetensors") else content + ".safetensors"
             g[cid] = {"class_type": "LoraLoaderModelOnly",
-                      "inputs": {"lora_name": name, "strength_model": 0.6, "model": prev},
+                      "inputs": {"lora_name": name, "strength_model": cstrength, "model": prev},
                       "_meta": {"title": f"content stage {tag}"}}
             prev = [cid, 0]
         if want_char:

--- a/tests/test_recipe_resolve.py
+++ b/tests/test_recipe_resolve.py
@@ -1,0 +1,114 @@
+"""The recipe resolver: values only, never topology.
+
+`tools/known-good/m-series-validated.graph.json` is the validated DR34 i2v motion recipe.
+The rule from CLAUDE.md is that resolve() patches VALUES and never structure — so the tests
+that matter here are the ones that would catch a change in what gets rendered, not a change
+in what gets returned.
+
+The content LoRA strength was hardcoded 0.6 for both stages until console#395 made it a
+per-pose setting. Everything below exists to prove that making it configurable did not move
+the default.
+"""
+import hashlib
+import json
+import pathlib
+
+import pytest
+
+from engine import recipe as recipe_mod
+
+WORKFLOW = pathlib.Path(__file__).parent.parent / "engine/workflows/ltx23_recipe.api.json"
+
+
+@pytest.fixture
+def graph():
+    return json.loads(WORKFLOW.read_text())
+
+
+def _hash(g):
+    return hashlib.sha256(json.dumps(g, sort_keys=True).encode()).hexdigest()
+
+
+BASE = dict(image_name="kf1.png", width=832, height=1216, prompt="a prompt")
+
+
+def test_a_pose_with_no_content_lora_is_the_graph_that_was_validated(graph):
+    """Every existing pose is this case, so this hash is the regression line.
+
+    If it moves, every validated render moved with it — and the symptom would be output
+    that is subtly different rather than an error.
+    """
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2")
+    # Pinned against the resolver as it stood BEFORE content strengths were configurable
+    # (verified by running both versions side by side over four configurations). A change
+    # here is a change to every validated render, so it should require deleting this line.
+    assert _hash(g) == "f3c7605015e2515aba55392078f26ff78e32d553df9cb5367e0ebd3851e3e7ea"
+    # And the property behind the hash, stated so a legitimate re-pin still has to hold it.
+    assert "9601" not in g
+    assert "9602" not in g
+
+
+def test_the_default_strengths_are_the_old_hardcode(graph):
+    """0.6 on both stages. A caller that names a LoRA and no strengths must get the
+    graph the hardcode produced, not a new number chosen while making it configurable."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           content_lora="sfbehind_LTX2_3_v0_1")
+    assert g["9601"]["inputs"]["strength_model"] == 0.6
+    assert g["9602"]["inputs"]["strength_model"] == 0.6
+
+
+def test_the_two_stages_take_different_strengths(graph):
+    """The whole point of the change. Stage 1 decides shape from noise; stage 2 refines the
+    2x-upscaled latent. A LoRA that carries motion but degrades anatomy wants to be low
+    where shape is decided and higher where detail is."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           content_lora="sfbehind_LTX2_3_v0_1",
+                           content_s1=0.3, content_s2=1.1)
+    assert g["9601"]["inputs"]["strength_model"] == 0.3
+    assert g["9602"]["inputs"]["strength_model"] == 1.1
+
+
+def test_a_content_strength_of_zero_is_honoured(graph):
+    """0 loads the LoRA and gives it no weight, which is how you measure its contribution.
+
+    It must not be treated as "unset" and replaced with 0.6 — the whole measurement would
+    then be of the wrong configuration.
+    """
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           content_lora="sfbehind_LTX2_3_v0_1",
+                           content_s1=0.0, content_s2=0.0)
+    assert g["9601"]["inputs"]["strength_model"] == 0.0
+    assert g["9602"]["inputs"]["strength_model"] == 0.0
+
+
+def test_the_content_lora_is_chained_ahead_of_the_character_lora(graph):
+    """Order is the topology, and it is not ours to change: content -> character -> branch.
+
+    If these ever swap, both LoRAs still load and the render still succeeds — at different
+    weights against different base latents. That is the kind of change nothing catches.
+    """
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           content_lora="sfbehind_LTX2_3_v0_1")
+    # stage 1: content 9601 feeds char 9621, which feeds branch 337
+    assert g["9621"]["inputs"]["model"] == ["9601", 0]
+    assert g["337"]["inputs"]["model"] == ["9621", 0]
+    # stage 2: same shape on 372
+    assert g["9622"]["inputs"]["model"] == ["9602", 0]
+    assert g["372"]["inputs"]["model"] == ["9622", 0]
+
+
+@pytest.mark.parametrize("value", ["none", "NONE", "", None])
+def test_none_in_any_spelling_renders_without_a_content_lora(graph, value):
+    """"none" is how the stack says off, and it must not become a filename lookup."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2", content_lora=value)
+    assert "9601" not in g and "9602" not in g
+
+
+def test_the_extension_is_added_when_missing(graph):
+    """The console stores bare names; ComfyUI wants the filename."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           content_lora="sfbehind_LTX2_3_v0_1")
+    assert g["9601"]["inputs"]["lora_name"] == "sfbehind_LTX2_3_v0_1.safetensors"
+    g2 = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                            content_lora="sfbehind_LTX2_3_v0_1.safetensors")
+    assert g2["9601"]["inputs"]["lora_name"] == "sfbehind_LTX2_3_v0_1.safetensors"


### PR DESCRIPTION
Engine half of console#395.

`resolve()` applied **0.6 to both stage branches** while character LoRAs got separate s1/s2. That's a configuration, not a default: stage 1 generates at half size from noise, stage 2 refines the 2x-upscaled latent. The `Lora` model in `app.py` already documents exactly this asymmetry — *"the lever for the case where a LoRA carries the motion but degrades anatomy: keep it low where the shape is decided, raise it where detail is"* — the recipe path just couldn't express it.

**Verified, not assumed.** Old and new resolvers run side by side over four configurations produced byte-identical graphs every time:

```
IDENTICAL  no content lora (every pose today)   5c78914bf6076ed2
IDENTICAL  content lora, default strengths      e0e293fd7c2efd03
IDENTICAL  content lora + char strengths        e0e293fd7c2efd03
IDENTICAL  no char lora either                  e58154a0536d75d1
```

`app.py` names `content_lora`/`content_s1`/`content_s2` explicitly rather than reusing `loras[0]`, which the recipe path already spends on the **character** LoRA. One list carrying two roles by index is how the wrong one gets loaded.

### This repo had no tests and no CI

It holds the resolver CLAUDE.md calls load-bearing — *"patch values only, never topology"* — while CI only built the image. Adds both.

Ten tests, including a pinned hash of the no-content-LoRA graph (the case every existing pose is), so moving the default requires deleting that line rather than not noticing. The suite was checked against a mutation — default nudged to 0.65 — to confirm it actually fails; a regression test that cannot fail is worse than none. One test pins the chain ORDER (content → character → branch), because if those swap both LoRAs still load and the render still succeeds, at different weights against different latents.