### PR TITLE
engine: log which LoRAs actually loaded, and check the content one exists

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -458,6 +458,21 @@ def resolve_lora(name: str) -> Path:
     return p
 
 
+
+def _checked_content_lora(name: str | None) -> str | None:
+    """Return the content LoRA name, having proven the file is actually there.
+
+    "none" and empty both mean "render without one" and are passed through untouched --
+    resolve() owns that vocabulary, and turning it into a filename lookup here is exactly
+    the bug that would make `none.safetensors` a 422.
+    """
+    if not name or name.strip().lower() == "none":
+        return name
+    n = name.strip()
+    resolve_lora(n if n.endswith(".safetensors") else n + ".safetensors")
+    return name
+
+
 def normalise(path: Path, width: int, height: int, allow_upscale: bool) -> str | None:
     """Bring a keyframe to the exact generation resolution. Returns what it did.
 
@@ -612,6 +627,7 @@ DEV_T = "diffusion_models/ltx-2.5-22b-dev-transformer-bf16.safetensors"
 DISTILLED_LORA = "loras/ltx-2.5-22b-distilled-lora-450-bf16.safetensors"
 
 
+
 def derive_size(path: Path) -> tuple[int, int]:
     """Recipe resolution is derived, not chosen: take the start frame's native
     size and round DOWN to /64, preserving aspect. 64 because the two-stage
@@ -731,7 +747,17 @@ def run_job(job: Job):
                 char_lora=(lora.name if lora else None),
                 char_s1=(lora.at(1) if lora else 0.8),
                 char_s2=(lora.at(2) if lora else 1.5),
-                content_lora=job.req.content_lora,
+                # Checked here, before anything is submitted. A LoRA that is merely absent
+                # should cost a 422 in the first second, not a failure deep in a render that
+                # has already held the GPU — and the message names the file and lists what IS
+                # present, which is what turned a past "no such lora 'pay_v2_e05'" into a
+                # one-look fix. resolve_lora also refuses anything path-shaped.
+                #
+                # This matters more for content LoRAs than for character ones: they arrive in
+                # the bucket after a worker has booted, and the worker only syncs at boot, so
+                # "the pose names a LoRA this box has never heard of" is the expected failure
+                # rather than an exotic one.
+                content_lora=_checked_content_lora(job.req.content_lora),
                 content_s1=job.req.content_s1,
                 content_s2=job.req.content_s2,
                 img_compression=job.req.img_compression,
@@ -755,8 +781,21 @@ def run_job(job: Job):
             # validated is a field on the row and the API and console own it. Asserting it
             # here would mean re-introducing a second source of truth to compare against,
             # which is the bug this change removes.
-            job.notes.append(f"recipe {job.req.recipe!r} · {char} · graph {gh[:12]}")
-            print(f"[{job.id}] recipe {job.req.recipe!r} -> {w}x{h}, graph {gh}", flush=True)
+            # Read back from the RESOLVED GRAPH, not from the request. The request is what
+            # was asked for; the graph is what will render, and those differ exactly when
+            # something has gone wrong — a field silently dropped (this model has no
+            # extra="forbid", so an older engine ignores unknown keys without complaint), a
+            # name that failed its "none" check, a strength that fell back to a default.
+            # A log that repeats the request would agree with itself in precisely the cases
+            # worth catching.
+            #
+            # Absence is stated, never implied. "content none" and no line at all look the
+            # same to a reader trying to work out whether a LoRA loaded.
+            job.notes.append(
+                f"recipe {job.req.recipe!r} · {recipe_mod.lora_stack_note(graph)} · graph {gh[:12]}"
+            )
+            print(f"[{job.id}] recipe {job.req.recipe!r} -> {w}x{h}, "
+                  f"{recipe_mod.lora_stack_note(graph)}, graph {gh}", flush=True)
             (workdir / "graph.json").write_text(json.dumps(graph, indent=1))
             job.stages = comfy.describe_stages(graph)
             job.prompt_id = cf.submit(graph)

--- a/engine/recipe.py
+++ b/engine/recipe.py
@@ -116,3 +116,30 @@ def graph_hash(g: dict) -> str:
             if field in v.get("inputs", {}) and not isinstance(v["inputs"][field], list):
                 v["inputs"][field] = "<seed>"
     return hashlib.sha256(json.dumps(h, sort_keys=True).encode()).hexdigest()
+
+
+def lora_stack_note(graph: dict) -> str:
+    """Which LoRAs this graph actually loads, per stage, as a one-line proof.
+
+    Built by inspecting the resolved graph's LoraLoaderModelOnly nodes rather than the
+    request that produced them, so the line is evidence of what will render. The node ids
+    are the ones recipe.resolve() writes: 9601/9602 content, 9621/9622 character.
+
+    Both stages are printed only when they differ. A character LoRA at 0.8/1.5 is the
+    validated pair and reads better as "@0.8/1.5" than as two identical numbers repeated.
+    """
+    def pair(n1: str, n2: str, label: str) -> str:
+        a, b = graph.get(n1), graph.get(n2)
+        if not a and not b:
+            return f"{label} none"
+        name = (a or b)["inputs"]["lora_name"]
+        s1 = a["inputs"]["strength_model"] if a else None
+        s2 = b["inputs"]["strength_model"] if b else None
+        # A LoRA on one stage only is legal but unusual enough to name explicitly.
+        if s1 is None or s2 is None:
+            stage = "stage1" if s1 is not None else "stage2"
+            return f"{label} {name} @{s1 if s1 is not None else s2} ({stage} only)"
+        strengths = f"{s1}" if s1 == s2 else f"{s1}/{s2}"
+        return f"{label} {name} @{strengths}"
+
+    return f"{pair('9621', '9622', 'char')} · {pair('9601', '9602', 'content')}"

--- a/tests/test_recipe_resolve.py
+++ b/tests/test_recipe_resolve.py
@@ -112,3 +112,56 @@ def test_the_extension_is_added_when_missing(graph):
     g2 = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
                             content_lora="sfbehind_LTX2_3_v0_1.safetensors")
     assert g2["9601"]["inputs"]["lora_name"] == "sfbehind_LTX2_3_v0_1.safetensors"
+
+
+# ---------------------------------------------------------------------------------------
+# The log line that proves which LoRAs actually loaded.
+#
+# Built from the RESOLVED GRAPH, not the request. Those differ exactly when something has
+# gone wrong — a field silently dropped (the engine request model has no extra="forbid", so
+# an older engine ignores unknown keys without complaint), a "none" check that missed, a
+# strength that fell back to a default. A log echoing the request would agree with itself
+# in precisely the cases worth catching.
+# ---------------------------------------------------------------------------------------
+# Lives in recipe.py, not app.py: it reads the graph resolve() produced, and app.py
+# imports comfy, which a pure test run has no reason to need.
+from engine.recipe import lora_stack_note  # noqa: E402
+
+
+def test_the_note_names_both_loras_and_their_strengths(graph):
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2", char_s1=0.8, char_s2=1.5,
+                           content_lora="sfbehind_LTX2_3_v0_1", content_s1=0.35, content_s2=1.25)
+    note = lora_stack_note(g)
+    assert "char k3lly2026_v2.safetensors @0.8/1.5" in note
+    assert "content sfbehind_LTX2_3_v0_1.safetensors @0.35/1.25" in note
+
+
+def test_absence_is_stated_not_implied(graph):
+    """"content none" and no mention at all read identically to someone asking whether a
+    LoRA loaded. Every pose today is this case, so it is the line that will be read most."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2")
+    assert "content none" in lora_stack_note(g)
+
+
+def test_no_character_lora_is_also_stated(graph):
+    g = recipe_mod.resolve(graph, **BASE, char_lora="none",
+                           content_lora="sfbehind_LTX2_3_v0_1")
+    note = lora_stack_note(g)
+    assert "char none" in note
+    assert "content sfbehind_LTX2_3_v0_1.safetensors" in note
+
+
+def test_equal_strengths_are_not_printed_twice(graph):
+    """@0.6 rather than @0.6/0.6 — the common case should be the short one."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           content_lora="sfbehind_LTX2_3_v0_1")
+    assert "content sfbehind_LTX2_3_v0_1.safetensors @0.6" in lora_stack_note(g)
+    assert "@0.6/0.6" not in lora_stack_note(g)
+
+
+def test_a_zero_strength_is_visible_in_the_log(graph):
+    """A LoRA loaded at 0 contributes nothing, and the log must not make that look like a
+    LoRA doing its job — this is the line someone reads when the output looks unchanged."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           content_lora="sfbehind_LTX2_3_v0_1", content_s1=0.0, content_s2=0.0)
+    assert "content sfbehind_LTX2_3_v0_1.safetensors @0.0" in lora_stack_note(g)


### PR DESCRIPTION
Answers "can I prove the recipe's LoRAs are being used?" — the note previously said `recipe 'X' · <char lora> · graph <hash>`, naming the **character** LoRA and nothing else.

Now, per segment at `[4/6]`:

```
no content lora (today)  recipe 'Doggy' · char k3lly2026_v2.safetensors @0.8/1.5 · content none · graph 2ba6e6d7
content at defaults      … · content sfbehind_LTX2_3_v0_1.safetensors @0.6 · …
content 0.35 / 1.25      … · content sfbehind_LTX2_3_v0_1.safetensors @0.35/1.25 · …
content at 0 (inert)     … · content sfbehind_LTX2_3_v0_1.safetensors @0.0 · …
no char lora             recipe 'Doggy' · char none · content sfbehind_LTX2_3_v0_1.safetensors @0.6 · …
```

**Read back from the resolved graph, not the request.** Those differ precisely when something has gone wrong — the request model has no `extra="forbid"`, so an engine older than its caller silently ignores unknown keys — and a log built from the request would agree with itself in exactly the cases worth catching.

**Absence is stated, not implied.** `content none` and no mention at all read identically to someone trying to work out whether a LoRA loaded, and that's the line read most often since it's every pose today. `@0.0` shows explicitly too: a LoRA at zero contributes nothing, and the log mustn't let that look like one doing its job.

### Also: the content LoRA is now checked before submit

`resolve_lora()` was only reached for `job.req.loras`, and even there inside a `try/except` for the coverage report — so a missing **content** LoRA surfaced deep in the render instead of as an immediate 422 naming the file and listing what is present.

That matters more for content LoRAs than character ones: they arrive in the bucket after a worker has booted, so "the pose names a LoRA this box has never heard of" is the expected failure, not an exotic one. `"none"` passes through untouched — turning it into a lookup would make `none.safetensors` a 422.

`lora_stack_note` lives in `recipe.py` rather than `app.py`: it reads the graph `resolve()` produced, and `app.py` imports `comfy`, which a pure test run has no reason to need.

15 tests.