### PR TITLE
engine: name the base model in every render's own record

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -818,9 +818,10 @@ def run_job(job: Job):
             # Absence is stated, never implied. "content none" and no line at all look the
             # same to a reader trying to work out whether a LoRA loaded.
             job.notes.append(
-                f"recipe {job.req.recipe!r} · {recipe_mod.lora_stack_note(graph)} · graph {gh[:12]}"
+                f"recipe {job.req.recipe!r} · base {recipe_mod.base_model_note(graph)} · "
+                f"{recipe_mod.lora_stack_note(graph)} · graph {gh[:12]}"
             )
-            print(f"[{job.id}] recipe {job.req.recipe!r} -> {w}x{h}, "
+            print(f"[{job.id}] recipe {job.req.recipe!r} -> {w}x{h}, base {ck}, "
                   f"{recipe_mod.lora_stack_note(graph)}, graph {gh}", flush=True)
             (workdir / "graph.json").write_text(json.dumps(graph, indent=1))
             job.stages = comfy.describe_stages(graph)

--- a/engine/recipe.py
+++ b/engine/recipe.py
@@ -118,6 +118,24 @@ def graph_hash(g: dict) -> str:
     return hashlib.sha256(json.dumps(h, sort_keys=True).encode()).hexdigest()
 
 
+def base_model_note(graph: dict) -> str:
+    """Which checkpoint this graph will actually load.
+
+    Read from the RESOLVED GRAPH rather than the request, for the same reason
+    lora_stack_note is: the request is what was asked for, the graph is what will render,
+    and those differ exactly when something has gone wrong.
+
+    2.3 checkpoints are monoliths, so every loader names the same file — 9500 is the one the
+    others follow.
+    """
+    for nid in ("9500", "9501", "9502"):
+        n = graph.get(nid)
+        if n and n.get("inputs", {}).get("ckpt_name"):
+            name = n["inputs"]["ckpt_name"]
+            return name[: -len(".safetensors")] if name.endswith(".safetensors") else name
+    return "unknown"
+
+
 def lora_stack_note(graph: dict) -> str:
     """Which LoRAs this graph actually loads, per stage, as a one-line proof.
 

--- a/tests/test_recipe_resolve.py
+++ b/tests/test_recipe_resolve.py
@@ -165,3 +165,28 @@ def test_a_zero_strength_is_visible_in_the_log(graph):
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
                            content_lora="sfbehind_LTX2_3_v0_1", content_s1=0.0, content_s2=0.0)
     assert "content sfbehind_LTX2_3_v0_1.safetensors @0.0" in lora_stack_note(g)
+
+
+def test_the_note_names_the_base_model(graph):
+    """A render's record must say which checkpoint it ran on, or two base models cannot be
+    told apart afterwards — which is the entire point of making it per-pose."""
+    from engine.recipe import base_model_note
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           checkpoint="10Eros_v1.5_bf16")
+    assert base_model_note(g) == "10Eros_v1.5_bf16"
+
+
+def test_the_default_base_model_is_named_too(graph):
+    """Not just overrides. A render on the default must say so explicitly, or "no mention"
+    and "the default" become indistinguishable in a log."""
+    from engine.recipe import base_model_note
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2")
+    assert base_model_note(g) == "sulphur_dev_bf16"
+
+
+def test_the_note_works_without_any_lora(graph):
+    """`ck` used to be defined inside the LoRA loop, so a pose with no character LoRA would
+    have raised NameError building its own log line. Reading the graph avoids that."""
+    from engine.recipe import base_model_note
+    g = recipe_mod.resolve(graph, **BASE, char_lora="none", checkpoint="ltx-2.3-22b-dev")
+    assert base_model_note(g) == "ltx-2.3-22b-dev"


### PR DESCRIPTION
A segment's note read `recipe X · char … · content … · graph <hash>` and never said which **checkpoint** it ran on. Fine when the checkpoint was a global; not now that a pose can override it (console#404) — two renders of the same pose on different base models were indistinguishable afterwards, which defeats the comparison the setting exists for.

```
[4/6] recipe 'Blowjob POV v1' · base sulphur_dev_bf16 · char k3lly2026_v2 @0.8/1.5 · content none · graph 2ba6e6d7
[4/6] recipe 'Blowjob POV v1' · base 10Eros_v1.5_bf16 · char k3lly2026_v2 @0.8/1.5 · content none · graph 2ba6e6d7
```

The note goes into the segment's `progress_log`, which the console already renders — so this is also where it becomes visible in the UI, without new UI.

**Read from the resolved graph, not the request** — same rule as `lora_stack_note`. The request is what was asked for; the graph is what will render, and those differ exactly when something has gone wrong.

> That also fixes a bug in my first attempt: I used the local `ck`, which is defined **inside the LoRA loop**, so a pose with no character LoRA would have hit `NameError` building its own log line. Reading the graph has no such scope problem, and there's a test for that case.

The default is named explicitly, not only overrides — otherwise "no mention" and "the default" are indistinguishable in a log.

3 tests, 18 total.