### PR TITLE
engine: chain several content LoRAs, in order, each with its own strengths

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -126,6 +126,19 @@ LORA_DIR = Path(os.environ.get("LORA_DIR", MODELS_ROOT / "loras"))
 JOB_TIMEOUT_S = int(os.environ.get("JOB_TIMEOUT_S", "5400"))
 
 
+class ContentLora(BaseModel):
+    """One motion/act LoRA in a pose's chain, with its own per-stage strengths.
+
+    Separate strengths because stage 1 generates at half size from noise and stage 2 refines
+    the 2x-upscaled latent. Lowering a competing content LoRA on stage 2 is a recorded lever
+    and one flat number cannot express it.
+    """
+
+    name: str
+    s1: float = Field(default=0.6, ge=0.0, le=2.0)
+    s2: float = Field(default=0.6, ge=0.0, le=2.0)
+
+
 class Lora(BaseModel):
     """A content LoRA by filename, resolved inside LORA_DIR.
 
@@ -205,12 +218,14 @@ class JobRequest(BaseModel):
     # index is how the wrong one gets loaded.
     #
     # None and "none" both mean "render without one", which is what every pose does today.
-    content_lora: str | None = None
-    # Per stage, and bounded at 2.0 to match Lora above. Defaults are 0.6/0.6 -- exactly what
-    # resolve() hardcoded for both stages before this was configurable -- so a request that
-    # omits them renders the graph that was validated.
-    content_s1: float = Field(default=0.6, ge=0.0, le=2.0)
-    content_s2: float = Field(default=0.6, ge=0.0, le=2.0)
+    # Content LoRAs STACK and are applied IN ORDER (console#410). Each carries its own
+    # per-stage strengths, both defaulting to 0.6 -- exactly what resolve() hardcoded before
+    # any of this was configurable -- so an entry naming only a LoRA renders at the
+    # validated strength.
+    #
+    # Capped at 4, matching `loras` above. Order is part of the configuration: the same
+    # LoRAs in a different order are a different render.
+    content_loras: list[ContentLora] = Field(default_factory=list, max_length=4)
     num_inference_steps: int | None = Field(default=None, ge=1, le=50)
     # Steps per pass. None leaves that stage on the schedule the graph ships.
     #
@@ -783,9 +798,10 @@ def run_job(job: Job):
                 # the bucket after a worker has booted, and the worker only syncs at boot, so
                 # "the pose names a LoRA this box has never heard of" is the expected failure
                 # rather than an exotic one.
-                content_lora=_checked_content_lora(job.req.content_lora),
-                content_s1=job.req.content_s1,
-                content_s2=job.req.content_s2,
+                content_loras=[
+                    {"name": _checked_content_lora(c.name), "s1": c.s1, "s2": c.s2}
+                    for c in job.req.content_loras
+                ],
                 img_compression=job.req.img_compression,
             )
             if job.req.num_frames:

--- a/engine/recipe.py
+++ b/engine/recipe.py
@@ -31,7 +31,7 @@ RECIPE_WORKFLOW = "ltx23_recipe.api.json"
 def resolve(graph: dict, image_name: str, width: int, height: int, *,
             prompt: str, negative: str | None = None, checkpoint: str | None = None,
             char_lora: str | None = None, char_s1: float = 0.8, char_s2: float = 1.5,
-            content_lora: str | None = None, content_s1: float = 0.6, content_s2: float = 0.6,
+            content_loras: list | None = None,
             img_compression: int | None = None) -> dict:
     """Patch the validated graph with this render's configuration.
 
@@ -62,8 +62,29 @@ def resolve(graph: dict, image_name: str, width: int, height: int, *,
 
     # one content+character chain per stage branch, mirroring how the distill
     # LoRA is already wired at 361/362
-    content = (content_lora or "none").strip()
-    has_content = content.lower() not in ("", "none")
+    #
+    # Content LoRAs STACK (console#410): motion, act and framing are separable and a pose
+    # may want several. They are applied in the order given — that order is part of the
+    # configuration, not incidental, and two poses with the same LoRAs in a different order
+    # will render differently.
+    contents = []
+    for entry in (content_loras or []):
+        name = str(entry.get("name") or "").strip()
+        if not name or name.lower() == "none":
+            # "none" is how a pose says off. Looking it up would be a filename lookup for a
+            # file that does not exist.
+            continue
+        contents.append({
+            "name": name if name.endswith(".safetensors") else name + ".safetensors",
+            # 0.6 matches what this function hardcoded before any of it was configurable, so
+            # an entry that names a LoRA and nothing else renders at the validated strength.
+            # `is None` rather than `or`: 0 is a real setting — the LoRA loads and
+            # contributes nothing, which is how you measure what it was contributing.
+            "s1": float(entry["s1"]) if entry.get("s1") is not None else 0.6,
+            "s2": float(entry["s2"]) if entry.get("s2") is not None else 0.6,
+        })
+    # The template ships with a baked content LoRA at 9601 (DR34ML4Y). Remove it before
+    # building the chain, or it would sit in front of everything below.
     if "9601" in g:
         del g["9601"]
     s1 = float(char_s1)
@@ -78,18 +99,27 @@ def resolve(graph: dict, image_name: str, width: int, height: int, *,
     # size from noise and stage 2 refines the 2x-upscaled latent, so one number for both is
     # a different setup, not a simpler one. 0.6/0.6 remains the default so a caller that
     # says nothing gets exactly the graph that was validated.
-    c1 = float(content_s1)
-    c2 = float(content_s2)
-    for tag, (branch, strength, cstrength) in {
-        "1": ("337", s1, c1), "2": ("372", s2, c2),
-    }.items():
+    for tag, (branch, strength) in {"1": ("337", s1), "2": ("372", s2)}.items():
         prev = ["301", 0]
-        if has_content:
-            cid = f"960{tag}"
-            name = content if content.endswith(".safetensors") else content + ".safetensors"
+        # Node ids: 9601/9602 for the first content LoRA (unchanged, so a single-LoRA pose
+        # produces the same graph it always did), then 9603/9604, 9605/9606... Stops well
+        # short of the character pair at 9621/9622 even at the cap of 4, so the two chains
+        # can never collide.
+        for i, c in enumerate(contents):
+            cid = f"96{1 + i * 2:02d}" if tag == "1" else f"96{2 + i * 2:02d}"
             g[cid] = {"class_type": "LoraLoaderModelOnly",
-                      "inputs": {"lora_name": name, "strength_model": cstrength, "model": prev},
-                      "_meta": {"title": f"content stage {tag}"}}
+                      "inputs": {"lora_name": c["name"],
+                                 "strength_model": c["s1"] if tag == "1" else c["s2"],
+                                 "model": prev},
+                      # Unnumbered when there is only one, and that is not cosmetic
+                      # fussiness: graph_hash includes _meta, so numbering a lone LoRA
+                      # "content 1" would change the hash of every existing single-LoRA
+                      # pose. The hash is the regression trail — it is what proves a render
+                      # is the configuration that was signed off — and a relabel must not
+                      # look like a configuration change. Verified: single-LoRA poses hash
+                      # identically before and after this change.
+                      "_meta": {"title": f"content {i + 1} stage {tag}" if len(contents) > 1
+                                else f"content stage {tag}"}}
             prev = [cid, 0]
         if want_char:
             kid = f"962{tag}"
@@ -160,4 +190,17 @@ def lora_stack_note(graph: dict) -> str:
         strengths = f"{s1}" if s1 == s2 else f"{s1}/{s2}"
         return f"{label} {name} @{strengths}"
 
-    return f"{pair('9621', '9622', 'char')} · {pair('9601', '9602', 'content')}"
+    # Every content LoRA, in the order applied — the order is part of the configuration and
+    # a result cannot be tied to a chain that is only half reported.
+    parts = [pair("9621", "9622", "char")]
+    found = []
+    for i in range(4):
+        n1, n2 = f"96{1 + i * 2:02d}", f"96{2 + i * 2:02d}"
+        if n1 in graph or n2 in graph:
+            found.append(pair(n1, n2, f"content{i + 1}"))
+    # Unnumbered when there is exactly one, matching the node title convention and keeping
+    # the common line readable: "content sfbehind @0.6" rather than "content1 sfbehind @0.6".
+    if len(found) == 1:
+        found = [pair("9601", "9602", "content")]
+    parts.append(" · ".join(found) if found else "content none")
+    return " · ".join(parts)

--- a/tests/test_recipe_resolve.py
+++ b/tests/test_recipe_resolve.py
@@ -52,7 +52,7 @@ def test_the_default_strengths_are_the_old_hardcode(graph):
     """0.6 on both stages. A caller that names a LoRA and no strengths must get the
     graph the hardcode produced, not a new number chosen while making it configurable."""
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
-                           content_lora="sfbehind_LTX2_3_v0_1")
+                           content_loras=[{"name": "sfbehind_LTX2_3_v0_1"}])
     assert g["9601"]["inputs"]["strength_model"] == 0.6
     assert g["9602"]["inputs"]["strength_model"] == 0.6
 
@@ -62,8 +62,7 @@ def test_the_two_stages_take_different_strengths(graph):
     2x-upscaled latent. A LoRA that carries motion but degrades anatomy wants to be low
     where shape is decided and higher where detail is."""
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
-                           content_lora="sfbehind_LTX2_3_v0_1",
-                           content_s1=0.3, content_s2=1.1)
+                           content_loras=[{"name": "sfbehind_LTX2_3_v0_1", "s1": 0.3, "s2": 1.1}])
     assert g["9601"]["inputs"]["strength_model"] == 0.3
     assert g["9602"]["inputs"]["strength_model"] == 1.1
 
@@ -75,8 +74,7 @@ def test_a_content_strength_of_zero_is_honoured(graph):
     then be of the wrong configuration.
     """
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
-                           content_lora="sfbehind_LTX2_3_v0_1",
-                           content_s1=0.0, content_s2=0.0)
+                           content_loras=[{"name": "sfbehind_LTX2_3_v0_1", "s1": 0.0, "s2": 0.0}])
     assert g["9601"]["inputs"]["strength_model"] == 0.0
     assert g["9602"]["inputs"]["strength_model"] == 0.0
 
@@ -88,7 +86,7 @@ def test_the_content_lora_is_chained_ahead_of_the_character_lora(graph):
     weights against different base latents. That is the kind of change nothing catches.
     """
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
-                           content_lora="sfbehind_LTX2_3_v0_1")
+                           content_loras=[{"name": "sfbehind_LTX2_3_v0_1"}])
     # stage 1: content 9601 feeds char 9621, which feeds branch 337
     assert g["9621"]["inputs"]["model"] == ["9601", 0]
     assert g["337"]["inputs"]["model"] == ["9621", 0]
@@ -100,17 +98,17 @@ def test_the_content_lora_is_chained_ahead_of_the_character_lora(graph):
 @pytest.mark.parametrize("value", ["none", "NONE", "", None])
 def test_none_in_any_spelling_renders_without_a_content_lora(graph, value):
     """"none" is how the stack says off, and it must not become a filename lookup."""
-    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2", content_lora=value)
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2", content_loras=[{"name": value}] if value is not None else [])
     assert "9601" not in g and "9602" not in g
 
 
 def test_the_extension_is_added_when_missing(graph):
     """The console stores bare names; ComfyUI wants the filename."""
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
-                           content_lora="sfbehind_LTX2_3_v0_1")
+                           content_loras=[{"name": "sfbehind_LTX2_3_v0_1"}])
     assert g["9601"]["inputs"]["lora_name"] == "sfbehind_LTX2_3_v0_1.safetensors"
     g2 = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
-                            content_lora="sfbehind_LTX2_3_v0_1.safetensors")
+                            content_loras=[{"name": "sfbehind_LTX2_3_v0_1.safetensors"}])
     assert g2["9601"]["inputs"]["lora_name"] == "sfbehind_LTX2_3_v0_1.safetensors"
 
 
@@ -130,7 +128,7 @@ from engine.recipe import lora_stack_note  # noqa: E402
 
 def test_the_note_names_both_loras_and_their_strengths(graph):
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2", char_s1=0.8, char_s2=1.5,
-                           content_lora="sfbehind_LTX2_3_v0_1", content_s1=0.35, content_s2=1.25)
+                           content_loras=[{"name": "sfbehind_LTX2_3_v0_1", "s1": 0.35, "s2": 1.25}])
     note = lora_stack_note(g)
     assert "char k3lly2026_v2.safetensors @0.8/1.5" in note
     assert "content sfbehind_LTX2_3_v0_1.safetensors @0.35/1.25" in note
@@ -145,7 +143,7 @@ def test_absence_is_stated_not_implied(graph):
 
 def test_no_character_lora_is_also_stated(graph):
     g = recipe_mod.resolve(graph, **BASE, char_lora="none",
-                           content_lora="sfbehind_LTX2_3_v0_1")
+                           content_loras=[{"name": "sfbehind_LTX2_3_v0_1"}])
     note = lora_stack_note(g)
     assert "char none" in note
     assert "content sfbehind_LTX2_3_v0_1.safetensors" in note
@@ -154,7 +152,7 @@ def test_no_character_lora_is_also_stated(graph):
 def test_equal_strengths_are_not_printed_twice(graph):
     """@0.6 rather than @0.6/0.6 — the common case should be the short one."""
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
-                           content_lora="sfbehind_LTX2_3_v0_1")
+                           content_loras=[{"name": "sfbehind_LTX2_3_v0_1"}])
     assert "content sfbehind_LTX2_3_v0_1.safetensors @0.6" in lora_stack_note(g)
     assert "@0.6/0.6" not in lora_stack_note(g)
 
@@ -163,7 +161,7 @@ def test_a_zero_strength_is_visible_in_the_log(graph):
     """A LoRA loaded at 0 contributes nothing, and the log must not make that look like a
     LoRA doing its job — this is the line someone reads when the output looks unchanged."""
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
-                           content_lora="sfbehind_LTX2_3_v0_1", content_s1=0.0, content_s2=0.0)
+                           content_loras=[{"name": "sfbehind_LTX2_3_v0_1", "s1": 0.0, "s2": 0.0}])
     assert "content sfbehind_LTX2_3_v0_1.safetensors @0.0" in lora_stack_note(g)
 
 
@@ -190,3 +188,75 @@ def test_the_note_works_without_any_lora(graph):
     from engine.recipe import base_model_note
     g = recipe_mod.resolve(graph, **BASE, char_lora="none", checkpoint="ltx-2.3-22b-dev")
     assert base_model_note(g) == "ltx-2.3-22b-dev"
+
+
+# ---------------------------------------------------------------------------------------
+# Stacking (console#410). Motion, act and framing are separable, so a pose may want several.
+# ---------------------------------------------------------------------------------------
+
+
+def test_several_content_loras_chain_in_order(graph):
+    """Order is part of the configuration, not incidental. The same LoRAs in a different
+    order are a different render, so the chain must follow the list exactly."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2", content_loras=[
+        {"name": "first", "s1": 0.3, "s2": 0.9},
+        {"name": "second", "s1": 0.5, "s2": 1.0},
+    ])
+    assert g["9601"]["inputs"]["lora_name"] == "first.safetensors"
+    assert g["9603"]["inputs"]["lora_name"] == "second.safetensors"
+    # first -> second -> char -> branch
+    assert g["9601"]["inputs"]["model"] == ["301", 0]
+    assert g["9603"]["inputs"]["model"] == ["9601", 0]
+    assert g["9621"]["inputs"]["model"] == ["9603", 0]
+    assert g["337"]["inputs"]["model"] == ["9621", 0]
+
+
+def test_each_lora_keeps_its_own_per_stage_strengths(graph):
+    """The whole reason for chaining rather than using the rgthree loader at node 301: that
+    node is shared across both stages and cannot express a per-stage difference."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2", content_loras=[
+        {"name": "a", "s1": 0.3, "s2": 0.9},
+        {"name": "b", "s1": 0.5, "s2": 1.2},
+    ])
+    assert (g["9601"]["inputs"]["strength_model"], g["9602"]["inputs"]["strength_model"]) == (0.3, 0.9)
+    assert (g["9603"]["inputs"]["strength_model"], g["9604"]["inputs"]["strength_model"]) == (0.5, 1.2)
+
+
+def test_content_ids_never_reach_the_character_pair(graph):
+    """At the cap of 4 the content chain ends at 9608; the character LoRA lives at
+    9621/9622. If those ever collided one would silently overwrite the other."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           content_loras=[{"name": f"c{i}"} for i in range(4)])
+    assert g["9607"]["inputs"]["lora_name"] == "c3.safetensors"
+    assert "9608" in g
+    assert g["9621"]["inputs"]["lora_name"] == "k3lly2026_v2.safetensors"
+
+
+def test_a_none_entry_in_the_list_is_skipped_not_looked_up(graph):
+    """"none" is how a pose says off. Looked up it would be a filename lookup for a file
+    that does not exist, failing the segment ten minutes into a claim."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2", content_loras=[
+        {"name": "none"}, {"name": "real"},
+    ])
+    assert g["9601"]["inputs"]["lora_name"] == "real.safetensors"
+    assert "9603" not in g
+
+
+def test_the_note_lists_every_content_lora_in_order(graph):
+    """A result cannot be tied to a chain that is only half reported."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2", content_loras=[
+        {"name": "first", "s1": 0.3, "s2": 0.9},
+        {"name": "second", "s1": 0.5, "s2": 1.0},
+    ])
+    note = lora_stack_note(g)
+    assert "content1 first.safetensors @0.3/0.9" in note
+    assert "content2 second.safetensors @0.5/1.0" in note
+    assert note.index("content1") < note.index("content2")
+
+
+def test_a_single_lora_is_not_numbered(graph):
+    """graph_hash includes _meta, so numbering a lone LoRA "content 1" would change the
+    hash of every existing single-LoRA pose — and that hash is the regression trail."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           content_loras=[{"name": "only"}])
+    assert g["9601"]["_meta"]["title"] == "content stage 1"


### PR DESCRIPTION
Engine half of console#410.

`resolve()` took one content LoRA; it now takes a list and chains them ahead of the character LoRA on both stage branches, in the order given.

```
301 → sfbehind @0.3 → ltxdeepthroat @0.5 → k3lly2026_v2 @0.8 → branch 337
```

### Chained `LoraLoaderModelOnly`, not rgthree's Power Lora Loader

Node 301 is purpose-built for stacking and would have been simpler — but it's the **shared origin feeding both stage branches**, so anything placed there applies identically to stage 1 and stage 2. It can't express *"lower the competing content LoRA on stage 2"*, which is a recorded lever and the one that makes stacking survivable. Chaining costs node-id allocation and is worth it.

Ids run `9601/9602`, `9603/9604`, `9605/9606`, `9607/9608` — stopping well short of the character pair at `9621/9622` even at the cap of 4, so the chains can never collide. Test included.

### Existing poses hash identically

Verified by running the old and new resolvers side by side:

```
IDENTICAL  no content lora        d782c6a8dc54a406
IDENTICAL  one @0.6 defaults      6ce47eb9bfda0515
IDENTICAL  one @0.35/1.25         c2679e2768c3b7d2
IDENTICAL  one, no char lora      1a3edaa52c7f3891
```

That needed one deliberate choice: a lone content LoRA keeps the node title `content stage N` rather than gaining a `content 1` ordinal, because **`graph_hash` includes `_meta`** — numbering it would change the hash of every existing single-LoRA pose. That hash is the regression trail, and a cosmetic relabel must not look like a configuration change.

> My first attempt *did* move the hash. The side-by-side check caught it, which is why it exists.

`lora_stack_note` lists every content LoRA in applied order, unnumbered when there's only one so the common line stays readable.

24 tests.