### PR TITLE
engine: purge a finished render's local media, keep its record

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -44,6 +44,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 import comfy
+import purge as purge_mod
 import recipe as recipe_mod
 import ltx_grid
 
@@ -1062,6 +1063,27 @@ def list_recipes():
     return {"character": d.get("character"), "characters": d.get("characters", {}),
             "sources": d.get("sources", {}), "labels": d.get("labels", {}),
             "definitions": d.get("definitions", {}), "recipes": d.get("recipes", {})}
+
+@app.post("/job/{job_id}/purge")
+def purge_job(job_id: str):
+    """Drop a finished job's local media once it is safely uploaded.
+
+    Called by the daemon AFTER a successful upload, never before — the local file is the
+    only copy until that upload lands, and reclaiming disk is not worth risking a render.
+
+    Keeps graph.json and prompt.txt; see engine/purge.py for why.
+    """
+    return purge_mod.purge_job_dir(JOBS_DIR / job_id)
+
+
+@app.post("/jobs/purge-all")
+def purge_all_jobs(keep_recent: int = 5):
+    """One-time sweep of everything already on disk (console#380)."""
+    r = purge_mod.purge_all(JOBS_DIR, keep_recent=keep_recent)
+    print(f"[purge] swept {r['dirs_purged']} job dirs, {r['files_removed']} files, "
+          f"{r['freed_bytes'] / 1e9:.2f} GB", flush=True)
+    return r
+
 
 @app.get("/health")
 def health():

--- a/engine/purge.py
+++ b/engine/purge.py
@@ -1,0 +1,69 @@
+"""Reclaiming a finished render's local media (console#380).
+
+Pure filesystem logic, deliberately in its own module rather than app.py: app.py imports
+comfy, which drags in the whole ComfyUI client, and a rule about which files to delete
+should be testable without any of that. Same reason lora_stack_note lives in recipe.py.
+
+WHAT GOES AND WHAT STAYS
+
+    out.mp4 and the keyframe pngs are ~2.7 GB across 500 jobs and grow by ~5 MB per render,
+    forever. By the time this runs they are duplicates: the daemon uploads to S3 first and
+    only then asks for the purge.
+
+    graph.json and prompt.txt are NOT duplicates. Together they are ~7 MB across those same
+    500 jobs — 0.3% of the space — and they are the only local record of what a render
+    actually did: which LoRAs at which strengths, against which checkpoint, from which
+    prompt. That record answered "which base model did job 905e9265 use" without re-running
+    anything. Deleting it to reclaim 7 MB would be a bad trade.
+"""
+from pathlib import Path
+
+PURGE_SUFFIXES = (".mp4", ".png", ".jpg", ".jpeg", ".webp", ".webm")
+KEEP_NAMES = ("graph.json", "prompt.txt")
+
+
+def purge_job_dir(workdir: Path) -> dict:
+    """Delete a finished job's media, keep its record. Returns what went."""
+    removed, freed = [], 0
+    if not workdir.is_dir():
+        return {"removed": [], "freed_bytes": 0, "missing": True}
+    for f in sorted(workdir.iterdir()):
+        if not f.is_file() or f.name in KEEP_NAMES:
+            continue
+        if f.suffix.lower() not in PURGE_SUFFIXES:
+            # Only known media is removed. Anything else in a job dir is there for a reason
+            # nobody has written down, and a purge should not be what discovers what.
+            continue
+        try:
+            size = f.stat().st_size
+            f.unlink()
+            removed.append(f.name)
+            freed += size
+        except OSError as e:
+            # One unlink failing must not abort the rest — a file held open elsewhere is a
+            # reason to skip it, not to leave the other 5 MB behind.
+            print(f"[purge] {f}: {type(e).__name__}: {e}", flush=True)
+    return {"removed": removed, "freed_bytes": freed, "missing": False}
+
+
+def purge_all(jobs_dir: Path, keep_recent: int = 5) -> dict:
+    """Sweep everything already on disk (the one-time half of console#380).
+
+    `keep_recent` leaves the newest few dirs alone. A render that finished seconds ago may
+    still be being fetched by the daemon, and there is no coordination between this sweep
+    and an in-flight job — so the newest are skipped rather than raced.
+    """
+    if not jobs_dir.is_dir():
+        return {"dirs_purged": 0, "files_removed": 0, "freed_bytes": 0, "skipped_recent": []}
+    dirs = sorted((d for d in jobs_dir.iterdir() if d.is_dir()),
+                  key=lambda d: d.stat().st_mtime, reverse=True)
+    skipped = [d.name for d in dirs[:keep_recent]]
+    freed = files = touched = 0
+    for d in dirs[keep_recent:]:
+        r = purge_job_dir(d)
+        if r["removed"]:
+            touched += 1
+            files += len(r["removed"])
+            freed += r["freed_bytes"]
+    return {"dirs_purged": touched, "files_removed": files,
+            "freed_bytes": freed, "skipped_recent": skipped}

--- a/tests/test_purge.py
+++ b/tests/test_purge.py
@@ -1,0 +1,85 @@
+"""Purging a finished render's local media (console#380).
+
+out.mp4 and the keyframe pngs are ~2.7 GB across 500 jobs and grow by ~5 MB per render,
+forever. They are duplicates by the time this runs — the daemon uploads to S3 first.
+
+graph.json and prompt.txt are NOT duplicates. Together they are ~7 MB across those same 500
+jobs and are the only local record of what a render actually did: which LoRAs at which
+strengths, against which checkpoint, from which prompt. Deleting them to reclaim 0.3% of the
+space would be a bad trade, and these tests are what stops a future "purge everything"
+simplification.
+"""
+import json
+
+import pytest
+
+from engine.purge import purge_all, purge_job_dir
+
+
+@pytest.fixture
+def jobdir(tmp_path):
+    d = tmp_path / "abc123"
+    d.mkdir()
+    (d / "out.mp4").write_bytes(b"x" * 5_000_000)
+    (d / "kf1.png").write_bytes(b"y" * 1_300_000)
+    (d / "graph.json").write_text(json.dumps({"9601": {}}))
+    (d / "prompt.txt").write_text("k3lly2026, a woman...")
+    return d
+
+
+def test_the_media_goes(jobdir):
+    r = purge_job_dir(jobdir)
+    assert not (jobdir / "out.mp4").exists()
+    assert not (jobdir / "kf1.png").exists()
+    assert set(r["removed"]) == {"out.mp4", "kf1.png"}
+    assert r["freed_bytes"] == 6_300_000
+
+
+def test_the_record_stays(jobdir):
+    """This is the assertion that matters. graph.json answered "which base model did job
+    905e9265 use" without re-running anything; it costs 13 KB."""
+    purge_job_dir(jobdir)
+    assert (jobdir / "graph.json").exists()
+    assert (jobdir / "prompt.txt").exists()
+    assert json.loads((jobdir / "graph.json").read_text()) == {"9601": {}}
+
+
+def test_purging_twice_is_harmless(jobdir):
+    """It runs after every upload, and an upload can be retried."""
+    purge_job_dir(jobdir)
+    r = purge_job_dir(jobdir)
+    assert r["removed"] == []
+    assert r["freed_bytes"] == 0
+
+
+def test_a_missing_directory_is_reported_not_raised(tmp_path):
+    """A job dir cleaned by hand, or a job that never wrote one. Purging must not fail the
+    segment that just succeeded."""
+    r = purge_job_dir(tmp_path / "does-not-exist")
+    assert r["missing"] is True
+    assert r["removed"] == []
+
+
+def test_unknown_file_types_are_left_alone(jobdir):
+    """Only known media is removed. Anything else in a job dir is there for a reason nobody
+    has written down, and a purge should not be the thing that discovers what."""
+    (jobdir / "notes.md").write_text("something someone left")
+    purge_job_dir(jobdir)
+    assert (jobdir / "notes.md").exists()
+
+
+def test_the_sweep_leaves_the_newest_dirs_alone(tmp_path):
+    """A render that finished seconds ago may still be being fetched by the daemon, and the
+    sweep has no coordination with in-flight jobs. Skipping the newest is cheaper than a
+    race whose loser is a lost render."""
+    import os, time
+    for i in range(8):
+        d = tmp_path / f"job{i}"
+        d.mkdir()
+        (d / "out.mp4").write_bytes(b"x" * 1000)
+        os.utime(d, (time.time() - (8 - i) * 60,) * 2)   # job7 newest
+    r = purge_all(tmp_path, keep_recent=3)
+    assert set(r["skipped_recent"]) == {"job7", "job6", "job5"}
+    assert (tmp_path / "job7" / "out.mp4").exists()
+    assert not (tmp_path / "job0" / "out.mp4").exists()
+    assert r["dirs_purged"] == 5


### PR DESCRIPTION
Engine half of console#380.

```
out.mp4     490 files, 1.83 GB   ← duplicates; S3 has them
pngs        604 files, 0.85 GB   ← duplicates
graph.json  495 files, 6.4 MB    ← the only local record
prompt.txt  531 files            ← the only local record
```

`out.mp4` and the keyframe pngs are **2.7 GB across 500 job dirs**, growing ~5 MB per render forever. By the time this runs they're duplicates — the daemon uploads first and only then asks.

### graph.json and prompt.txt stay, deliberately

Together they're **~7 MB across those same 500 jobs — 0.3% of the space** — and they're the only local record of what a render actually did: which LoRAs at which strengths, against which checkpoint, from which prompt.

That record answered *"which base model did job 905e9265 use?"* today without re-running anything. Deleting it to reclaim 7 MB would be a bad trade, and there's a test whose only job is to stop a future "purge everything" simplification.

**Only known media suffixes are removed.** Anything else in a job dir is there for a reason nobody wrote down, and a purge shouldn't be what discovers what.

### Two endpoints

- `POST /job/{id}/purge` — the per-render case, called by the daemon after upload
- `POST /jobs/purge-all` — the one-time sweep the ticket asks for

The sweep **skips the newest few dirs**: a render that finished seconds ago may still be being fetched, and there's no coordination between the sweep and an in-flight job. Skipping is cheaper than a race whose loser is a lost render.

Logic lives in `engine/purge.py`, not `app.py` — `app.py` imports `comfy`, and a rule about which files to delete should be testable without the whole ComfyUI client. Same reason `lora_stack_note` lives in `recipe.py`.

6 tests, 30 total.