### PR TITLE
engine: 'none.safetensors' means none, same as 'none'

### DIFF
--- a/engine/recipe.py
+++ b/engine/recipe.py
@@ -28,6 +28,26 @@ HERE = Path(__file__).parent
 RECIPE_WORKFLOW = "ltx23_recipe.api.json"
 
 
+def _is_none(name: str | None) -> bool:
+    """Is this the caller saying "no LoRA"?
+
+    Compared with the extension STRIPPED, which is the whole point. A bare "none" was always
+    excluded, but "none.safetensors" was not — and that is exactly what arrives once anything
+    upstream normalises the name before sending it. ComfyUI then rejects the graph with
+
+        9621 LoraLoaderModelOnly: lora_name: 'none.safetensors' not in [...]
+
+    ten minutes into a claimed segment. Seen in production 2026-09-04.
+
+    The daemon also filters this, and should. This is the last line: the engine builds the
+    graph, so it is the thing that must never build a loader for a file called "none".
+    """
+    n = (name or "").strip().lower()
+    if n.endswith(".safetensors"):
+        n = n[: -len(".safetensors")]
+    return n in ("", "none")
+
+
 def resolve(graph: dict, image_name: str, width: int, height: int, *,
             prompt: str, negative: str | None = None, checkpoint: str | None = None,
             char_lora: str | None = None, char_s1: float = 0.8, char_s2: float = 1.5,
@@ -70,7 +90,7 @@ def resolve(graph: dict, image_name: str, width: int, height: int, *,
     contents = []
     for entry in (content_loras or []):
         name = str(entry.get("name") or "").strip()
-        if not name or name.lower() == "none":
+        if _is_none(name):
             # "none" is how a pose says off. Looking it up would be a filename lookup for a
             # file that does not exist.
             continue
@@ -93,7 +113,7 @@ def resolve(graph: dict, image_name: str, width: int, height: int, *,
     # alone -- useful for judging what the LoRA is actually contributing, and
     # for a shot where the start frame already carries the identity.
     char_name = (char_lora or "").strip()
-    want_char = char_name.lower() not in ("", "none")
+    want_char = not _is_none(char_name)
     # Per stage, like the character strengths beside them. This was 0.6 hardcoded for BOTH
     # stages, which is a configuration rather than a default -- stage 1 generates at half
     # size from noise and stage 2 refines the 2x-upscaled latent, so one number for both is

--- a/tests/test_recipe_resolve.py
+++ b/tests/test_recipe_resolve.py
@@ -260,3 +260,29 @@ def test_a_single_lora_is_not_numbered(graph):
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
                            content_loras=[{"name": "only"}])
     assert g["9601"]["_meta"]["title"] == "content stage 1"
+
+
+@pytest.mark.parametrize("spelling", ["none", "NONE", "none.safetensors",
+                                      "None.safetensors", " none ", ""])
+def test_no_character_lora_in_any_spelling(graph, spelling):
+    """Seen in production 2026-09-04:
+
+        9621 LoraLoaderModelOnly: lora_name: 'none.safetensors' not in [...]
+
+    A bare "none" was always excluded. "none.safetensors" was not — and that is exactly what
+    arrives once anything upstream normalises the name before sending it. ComfyUI then
+    rejects the whole graph, ten minutes into a claimed segment.
+
+    The engine builds the graph, so it is the last thing that can refuse to build a loader
+    for a file called "none".
+    """
+    g = recipe_mod.resolve(graph, **BASE, char_lora=spelling)
+    assert "9621" not in g and "9622" not in g
+
+
+@pytest.mark.parametrize("spelling", ["none", "none.safetensors", "NONE.SafeTensors"])
+def test_no_content_lora_in_any_spelling(graph, spelling):
+    """Same trap on the content chain, which normalises names the same way."""
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           content_loras=[{"name": spelling}])
+    assert "9601" not in g and "9602" not in g


### PR DESCRIPTION
Hit in production today:

```
9621 LoraLoaderModelOnly: lora_name: 'none.safetensors' not in
  ['2ltsway-breastsway.comfy.safetensors', 'DR34ML4Y_LT3X_V3.safetensors', ...]
```

ComfyUI rejected the whole graph, ten minutes into a claimed segment.

`want_char` compared against the literal `"none"`. A bare `"none"` was always excluded; **`"none.safetensors"` was not** — and that's exactly what arrives once anything upstream normalises the name before sending it, which the daemon did.

The daemon filters this now (wanly-gpu-daemon#172) and should. But **the engine is what builds the graph**, so it's the last thing that can refuse to construct a loader for a file called "none" — and it wasn't refusing. Both ends now.

Extension is stripped before the comparison, and the same guard applies to the **content chain**, which normalises names identically and had the same latent trap.

8 parametrised cases, 33 tests.

> Note: the immediate production cause was that wanly-gpu-daemon#172 was merged but never deployed — the 3090 is still running `c841940`, which predates it. That worker cycle is happening alongside this.