### PR TITLE
engine: the base-model log line must read the graph, not a loop variable

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -838,7 +838,21 @@ def run_job(job: Job):
                 f"recipe {job.req.recipe!r} · base {recipe_mod.base_model_note(graph)} · "
                 f"{recipe_mod.lora_stack_note(graph)} · graph {gh[:12]}"
             )
-            print(f"[{job.id}] recipe {job.req.recipe!r} -> {w}x{h}, base {ck}, "
+            # base_model_note(graph), NOT the local `ck`. `ck` is assigned inside the
+            # `for lo in job.req.loras` loop above, so a render with NO character LoRA never
+            # binds it and this line raised
+            #
+            #   UnboundLocalError: local variable 'ck' referenced before assignment
+            #
+            # after the graph was already built — a segment failing on its own log line.
+            # Seen in production 2026-09-04, on the very "no character" path that had just
+            # been made selectable.
+            #
+            # The line above was fixed to read from the graph and this one was not, which is
+            # the whole lesson: a loop-scoped variable used after the loop is a bug whether
+            # or not one of its uses has been corrected.
+            print(f"[{job.id}] recipe {job.req.recipe!r} -> {w}x{h}, "
+                  f"base {recipe_mod.base_model_note(graph)}, "
                   f"{recipe_mod.lora_stack_note(graph)}, graph {gh}", flush=True)
             (workdir / "graph.json").write_text(json.dumps(graph, indent=1))
             job.stages = comfy.describe_stages(graph)

--- a/tests/test_recipe_resolve.py
+++ b/tests/test_recipe_resolve.py
@@ -286,3 +286,29 @@ def test_no_content_lora_in_any_spelling(graph, spelling):
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
                            content_loras=[{"name": spelling}])
     assert "9601" not in g and "9602" not in g
+
+
+def test_every_line_that_names_the_base_model_reads_it_from_the_graph():
+    """Both the segment note and its stdout twin report the base model, and they must derive
+    it from the same place. They did not.
+
+    The note was fixed to read the resolved graph; the print beside it kept using a local
+    `ck` assigned INSIDE the `for lo in job.req.loras` loop — so a render with NO character
+    LoRA never bound it and the segment died on its own log line:
+
+        UnboundLocalError: local variable 'ck' referenced before assignment
+
+    after the graph had already been built. Seen in production 2026-09-04, on the very
+    "no character" path that had just been made selectable.
+
+    Two lines stating one fact from two sources is the bug. This pins every such line to the
+    graph, which is the only thing that knows what will actually render.
+    """
+    import re
+
+    src = open("engine/app.py").read()
+    naming = [ln.strip() for ln in src.split("\n") if re.search(r"base \{", ln)]
+    assert naming, "expected at least one line naming the base model"
+    for ln in naming:
+        assert "base_model_note(graph)" in ln, (
+            f"this line derives the base model some other way: {ln}")


### PR DESCRIPTION
```
LtxEngineError: UnboundLocalError: local variable 'ck' referenced before assignment
```

`ck` is assigned inside `for lo in job.req.loras`. A render with **no character LoRA** never enters that loop, so `ck` was never bound — and the `print` below it referenced it anyway. The segment died on its own log line, *after* the graph had already been built successfully.

On the very "no character" path that had just been made selectable (console#412), which is the worst possible place for it.

### I half-fixed this earlier

I identified this exact hazard while adding the base model to the note, and changed `job.notes.append(...)` to read `base_model_note(graph)`. The `print` on the next line kept using `ck`. **A loop-scoped variable used after the loop is a bug whether or not one of its uses has been corrected**, and I stopped at the one I was looking at.

Both now read the resolved graph — the only thing that knows what will actually render.

### The test

Asserts that *every* line naming the base model derives it from the graph, rather than testing the one line I happened to fix. Verified by reintroducing the bug and confirming it fails.

40 tests.