### PR TITLE
engine: default the base model to 10Eros, and fetch what we default to

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -40,13 +40,25 @@ fi
 #
 # Sources are RECORDED, never guessed. The Lightricks and Comfy-Org entries come from
 # ~/LTX-2/download-ltx23.sh and download-gemma-comfy.sh on the 3090, which lived only on that
-# box. The two sulphur files are Sulphur 2, a drop-in LTX 2.3 replacement published at
-# SulphurAI/Sulphur-2-base; the distill LoRA is stored here under a shorter name.
+# box. The distill LoRA is Sulphur 2's, from SulphurAI/Sulphur-2-base, stored here under a
+# shorter name. The checkpoint is 10Eros v1.5 from TenStrip/LTX2.3-10Eros -- verified to be
+# the same 46,139,886,366-byte file the 3090 has been rendering on.
+#
+# THE CHECKPOINT HERE IS THE DEFAULT, and that is not a coincidence to be maintained by hand.
+# It must equal engine/recipe.py's DEFAULT_CHECKPOINT, which is asserted by
+# tests/test_recipe_resolve.py. A pod that fetches a checkpoint other than the default
+# reports it through the heartbeat, the API's model gate hides every default pose from it,
+# and it sits there claiming nothing -- indistinguishable from an empty queue.
+#
+# Only the default is fetched, not every checkpoint a pose might name. Each is ~46 GB, so
+# fetching both 10Eros and sulphur would take a cold boot from ~58 GB to ~104 and roughly
+# double time-to-first-claim. A pod simply is not offered poses it cannot render; the model
+# gate (wanly-api _model_gate, console#422) already handles that correctly.
 #
 # WHAT a pod needs is what a RENDER loads, which is not what the workflow template names and
 # not what the folder holds. The template says ltx-2.3-22b-dev.safetensors in three loaders,
-# but the recipe patches all three to sulphur_dev_bf16 before submission, so the dev
-# checkpoint never loads -- 43 GB that a pod would download and never open. Same for
+# but the recipe patches all three to the render's own checkpoint before submission, so the
+# dev checkpoint never loads -- 43 GB that a pod would download and never open. Same for
 # ltx-2.3-22b-distilled-lora-384-1.1: the recipe substitutes the sulphur distill LoRA.
 # Confirmed against the resolved graph.json of a real render rather than read off the graph
 # template. That is the difference between fetching 58 GB and fetching 108.
@@ -79,7 +91,7 @@ mkdir -p "$HF_HOME" 2>/dev/null
 
 # dest_dir_under_$MODELS|final_filename|repo|path_in_repo (empty = filename at repo root)
 _WANTED=(
-  "ltx-2.3/diffusion_models|sulphur_dev_bf16.safetensors|SulphurAI/Sulphur-2-base|"
+  "ltx-2.3/diffusion_models|10Eros_v1.5_bf16.safetensors|TenStrip/LTX2.3-10Eros|"
   "ltx-2.3/text_encoders|gemma_3_12B_it_fp8_scaled.safetensors|Comfy-Org/ltx-2|split_files/text_encoders/gemma_3_12B_it_fp8_scaled.safetensors"
   "ltx-2.3/latent_upscale_models|ltx-2.3-spatial-upscaler-x2-1.1.safetensors|Lightricks/LTX-2.3|"
   "loras|sulphur_distill_lora_condsafe.safetensors|SulphurAI/Sulphur-2-base|distill_loras/ltx-2.3-22b-distilled-lora-1.1_fro90_ceil72_condsafe.safetensors"

--- a/engine/recipe.py
+++ b/engine/recipe.py
@@ -27,6 +27,22 @@ from pathlib import Path
 HERE = Path(__file__).parent
 RECIPE_WORKFLOW = "ltx23_recipe.api.json"
 
+# The base model a render falls back to when the caller names none (console#431).
+#
+# THREE PLACES ANSWER THIS AND ALL THREE MUST AGREE:
+#
+#   * here -- what actually renders
+#   * download_models.sh's _WANTED -- what a cold container or pod actually HAS
+#   * wanly-api's LTX_STACK['checkpoint'] -- what the API gates claims against
+#
+# They live in two repos and cannot share a constant, so the coupling is held by
+# test_default_checkpoint_is_the_one_a_cold_pod_fetches() below, which reads the shell
+# script. A comment would not have been enough: the failure is silent. A pod that fetched
+# a different checkpoint than the default reports it through the heartbeat, the API's model
+# gate then hides every default pose from it, and it claims nothing at all -- which looks
+# like an empty queue rather than like a broken pod.
+DEFAULT_CHECKPOINT = "10Eros_v1.5_bf16"
+
 
 def _is_none(name: str | None) -> bool:
     """Is this the caller saying "no LoRA"?
@@ -59,7 +75,7 @@ def resolve(graph: dict, image_name: str, width: int, height: int, *,
     the handful of fields that vary between renders.
     """
     g = json.loads(json.dumps(graph))
-    ck = checkpoint or "sulphur_dev_bf16"
+    ck = checkpoint or DEFAULT_CHECKPOINT
     if not ck.endswith(".safetensors"):
         ck += ".safetensors"
     # 2.3 checkpoints are monoliths: every loader naming the file must move

--- a/tests/test_recipe_resolve.py
+++ b/tests/test_recipe_resolve.py
@@ -12,6 +12,7 @@ the default.
 import hashlib
 import json
 import pathlib
+import re
 
 import pytest
 
@@ -33,12 +34,21 @@ BASE = dict(image_name="kf1.png", width=832, height=1216, prompt="a prompt")
 
 
 def test_a_pose_with_no_content_lora_is_the_graph_that_was_validated(graph):
-    """Every existing pose is this case, so this hash is the regression line.
+    """The regression line for the RESOLVER: if this hash moves, output moved with it, and
+    the symptom would be renders that are subtly different rather than an error.
 
-    If it moves, every validated render moved with it — and the symptom would be output
-    that is subtly different rather than an error.
+    The checkpoint is named EXPLICITLY (console#431). It used to be left to the default,
+    which quietly made this hash a pin on two separate things — how the resolver patches a
+    graph, and which base model happens to be default. When the default moved to 10Eros the
+    hash moved with it, and a tripwire that fires on an intended policy change is one that
+    gets re-pinned by reflex until it stops guarding anything.
+
+    Verified at the time of the switch: naming sulphur here reproduces the pinned hash
+    byte-for-byte, and the only difference against the new default is ckpt_name on nodes
+    9500/9501/9502. The resolver itself did not move.
     """
-    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2")
+    g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                           checkpoint="sulphur_dev_bf16")
     # Pinned against the resolver as it stood BEFORE content strengths were configurable
     # (verified by running both versions side by side over four configurations). A change
     # here is a change to every validated render, so it should require deleting this line.
@@ -46,6 +56,23 @@ def test_a_pose_with_no_content_lora_is_the_graph_that_was_validated(graph):
     # And the property behind the hash, stated so a legitimate re-pin still has to hold it.
     assert "9601" not in g
     assert "9602" not in g
+
+
+def test_the_default_changes_nothing_but_the_checkpoint(graph):
+    """What moving the default is allowed to do, stated as a test (console#431).
+
+    Exactly three loaders change and nothing else. 2.3 checkpoints are monoliths, so all
+    three must move together — a default that reached two of them would load two different
+    base models in one render.
+    """
+    explicit = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2",
+                                  checkpoint="sulphur_dev_bf16")
+    default = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2")
+    differing = {k for k in explicit if explicit[k] != default[k]}
+    assert differing == {"9500", "9501", "9502"}
+    for nid in differing:
+        assert default[nid]["inputs"]["ckpt_name"] == \
+            f"{recipe_mod.DEFAULT_CHECKPOINT}.safetensors"
 
 
 def test_the_default_strengths_are_the_old_hardcode(graph):
@@ -179,7 +206,28 @@ def test_the_default_base_model_is_named_too(graph):
     and "the default" become indistinguishable in a log."""
     from engine.recipe import base_model_note
     g = recipe_mod.resolve(graph, **BASE, char_lora="k3lly2026_v2")
-    assert base_model_note(g) == "sulphur_dev_bf16"
+    assert base_model_note(g) == recipe_mod.DEFAULT_CHECKPOINT
+
+
+def test_default_checkpoint_is_the_one_a_cold_pod_fetches():
+    """The default and the download list must name the same checkpoint (console#431).
+
+    They are separate files in separate languages and nothing but this test connects them.
+    It is here rather than in a comment because the failure is silent and expensive: a pod
+    that fetched sulphur while the default is 10Eros boots green, reports sulphur through
+    its heartbeat, and is then refused every default pose by the API's model gate. It
+    claims nothing, and an idle pod is indistinguishable from an empty queue.
+
+    Parsed out of the _WANTED array rather than grepped for the bare name, so that a stale
+    mention of the checkpoint in a nearby comment cannot make this pass.
+    """
+    script = (pathlib.Path(__file__).parent.parent / "download_models.sh").read_text()
+    rows = re.findall(r'^\s*"([^"]+\|[^"]*)"\s*$', script, re.MULTILINE)
+    fetched = {r.split("|")[1] for r in rows if r.split("|")[0].endswith("diffusion_models")}
+    assert fetched == {f"{recipe_mod.DEFAULT_CHECKPOINT}.safetensors"}, (
+        f"download_models.sh fetches {fetched}, but the engine defaults to "
+        f"{recipe_mod.DEFAULT_CHECKPOINT!r}"
+    )
 
 
 def test_the_note_works_without_any_lora(graph):


### PR DESCRIPTION
Part of DavidJBarnes/wanly-console#431 (the wanly-api half is a separate PR).

## What

- `engine/recipe.py` gains `DEFAULT_CHECKPOINT = "10Eros_v1.5_bf16"`; `resolve()` falls back to it instead of the `"sulphur_dev_bf16"` literal.
- `download_models.sh` `_WANTED` fetches `10Eros_v1.5_bf16.safetensors` from `TenStrip/LTX2.3-10Eros` in place of sulphur.
- A test ties the two together.

## Why 10Eros

Measured against production, not assumed:

| | |
|---|---|
| poses naming `10Eros_v1.5_bf16` | **9** |
| poses naming `sulphur_dev_bf16` | 6 |
| poses naming nothing | 1 |
| segments last 30d, 10Eros | **115** |
| segments last 30d, sulphur | 30 |

The nine are hand-cloned duplicates of the sulphur poses (`Doggystyle` / `Doggystyle - 10eros`). That duplication exists *only* because the default points at sulphur.

## Why this repo has two of the three changes

The default is answered in three places, in two repos:

| where | question it answers |
|---|---|
| `engine/recipe.py` | what actually renders |
| `download_models.sh` | what a cold container/pod actually **has** |
| wanly-api `LTX_STACK['checkpoint']` | what the API gates claims against |

Moving one without the others is the shape of #430 — two live answers to one question. The cross-repo pair can't share a constant, so `test_default_checkpoint_is_the_one_a_cold_pod_fetches()` parses `_WANTED` out of the shell script and asserts it names `DEFAULT_CHECKPOINT`.

That guard is a test rather than a comment because **the failure is silent**: a pod that fetched a different checkpoint boots green, reports it through the heartbeat, is then refused every default pose by `_model_gate()` (console#422), and claims nothing. An idle pod is indistinguishable from an empty queue. Confirmed the test actually fails when the two are made to disagree.

## Decisions

**Only the default is fetched, not both.** Each checkpoint is ~46 GB; carrying both would take a cold boot from ~58 GB to ~104 and roughly double time-to-first-claim. A pod is simply not offered poses it cannot render — the model gate already handles that, and it's the argument this script already makes for itself ("WHAT a pod needs is what a RENDER loads").

**The distill LoRA does not change.** It stays Sulphur 2's `sulphur_distill_lora_condsafe`. Proven rather than assumed: the nine 10Eros poses have rendered 115 segments on exactly that pairing.

## The tripwire, and why it was re-pinned rather than just updated

`test_a_pose_with_no_content_lora_is_the_graph_that_was_validated` failed. It was pinning two things at once — how the resolver patches a graph, *and* which base model is default — because it left the checkpoint unset. A tripwire that fires on an intended policy change gets re-pinned by reflex until it guards nothing, so it now names sulphur explicitly and goes back to guarding only the resolver.

Verified before changing it: naming sulphur reproduces the pinned hash `f3c7605…e3e7ea` **byte-for-byte**, and the only difference against the new default is `ckpt_name` on nodes 9500/9501/9502. The resolver did not move. That property is now its own test (`test_the_default_changes_nothing_but_the_checkpoint`), which also proves all three loaders move together — a monolithic 2.3 checkpoint reaching only two of them would load two base models in one render.

## Verification

- `pytest tests/` — 42 passed
- guard test confirmed to fail on a deliberately mismatched download list
- `bash -n download_models.sh` clean
- `TenStrip/LTX2.3-10Eros` fetched anonymously over HTTP: **200, content-length 46,139,886,366** — byte-for-byte the size of the file already on the 3090, public and ungated

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J