### PR TITLE
start.sh: the boot log should print config values, not prose

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -132,17 +132,14 @@ FRIENDLY_NAME=${FRIENDLY_NAME:-ltx-${RUNPOD_POD_ID:-$(hostname)}}
 ENGINE=ltx
 LTX_ENGINE_URL=http://localhost:${API_PORT:-8190}
 COMFYUI_URL=http://localhost:${COMFY_PORT:-8188}
-# EMPTY on purpose. With a path set, the daemon takes ownership of ComfyUI: it checks for
-# custom node packs and clones the ones it thinks are missing, and it runs a "resource sync"
-# that downloads model files from S3. Both are WAN-era jobs and both break an LTX worker:
+# EMPTY on purpose. With a path set, the daemon takes ownership of ComfyUI and checks for
+# custom node packs, cloning the ones it thinks are missing. That is a WAN-era job and it
+# breaks an LTX worker: it cloned Frame-Interpolation and ReActor into the LTX ComfyUI, and
+# ReActor unpinned requirements pull transformers >=5, which breaks every workflow.
 #
-#   * the node check cloned Frame-Interpolation and ReActor into the LTX ComfyUI, and
-#     ReActor's unpinned requirements pull transformers >=5, which breaks every workflow
-#   * the resource sync tried to fetch rife49.pth, deleted with WAN, got a 404 from S3 and
-#     exited -- restart-looping a pod that had just got past ComfyUI for the first time:
-#
-#         ERROR Resource rife49.pth: download failed ... HTTP 404
-#         ERROR Resource sync failed. Exiting.
+# It also used to run a "resource sync" that fetched model files from S3 and exited the
+# daemon when that failed, restart-looping the pod. That is gone (wanly-gpu-daemon#175);
+# the node check is now the only reason this stays empty.
 #
 # ltx-engine owns this ComfyUI. The daemon drives the engine and syncs character LoRAs
 # through LORA_CACHE_DIR; it has no business installing nodes or models.
@@ -155,8 +152,19 @@ EOF
 # Dump the resolved config so a parity problem is visible in the first lines of the boot log
 # rather than after a day of results. Secrets redacted: container logs are surfaced in consoles,
 # and a plain `cat` printed QUEUE_API_KEY and RUNPOD_API_KEY in the clear.
+#
+# COMMENTS ARE STRIPPED. This dump exists to show resolved VALUES; the reasoning belongs in
+# this file, not in every boot log. The comment above COMFYUI_PATH used to quote the very
+# log lines it was explaining --
+#
+#     ERROR Resource rife49.pth: download failed ... HTTP 404
+#
+# -- so every healthy boot printed two lines that grep as ERROR, and one of them was read as
+# a live failure during a routine restart. That misread is what filed wanly-gpu-daemon#175.
 echo "Daemon config:"
-sed -E 's/^(.*(KEY|TOKEN|SECRET|PASSWORD))=.+$/\1=<redacted>/' "$DAEMON_DIR/.env" | sed 's/^/  /'
+grep -vE '^[[:space:]]*(#|$)' "$DAEMON_DIR/.env" \
+  | sed -E 's/^(.*(KEY|TOKEN|SECRET|PASSWORD))=.+$/\1=<redacted>/' \
+  | sed 's/^/  /'
 
 # ---------- 4. ComfyUI ----------
 # Fail LOUDLY on a driver too old for this torch build, rather than letting ComfyUI die on

--- a/tests/test_boot_log_config_dump.py
+++ b/tests/test_boot_log_config_dump.py
@@ -1,0 +1,81 @@
+"""The boot log's config dump must print values, not prose (wanly-gpu-daemon#175).
+
+start.sh writes the daemon .env with a heredoc that includes explanatory comments, then
+dumps the resolved file so a parity problem is visible early. The comments went with it --
+including one that quoted the very log lines it was explaining:
+
+    ERROR Resource rife49.pth: download failed ... HTTP 404
+    ERROR Resource sync failed. Exiting.
+
+So every healthy boot printed two lines that grep as ERROR. One was read as a live failure
+during a routine restart, which is what filed the ticket.
+
+The pipeline under test is EXTRACTED FROM start.sh rather than restated here. A copy would
+pass while the real dump regressed, which is the failure mode this whole ticket is about.
+"""
+import pathlib
+import re
+import subprocess
+
+START_SH = pathlib.Path(__file__).parent.parent / "start.sh"
+
+FAKE_ENV = """QUEUE_URL=http://api.wanly22.com:8001
+FRIENDLY_NAME=ltx-abc123
+ENGINE=ltx
+# EMPTY on purpose. The daemon would take ownership of ComfyUI.
+#
+#     ERROR Resource rife49.pth: download failed ... HTTP 404
+#     ERROR Resource sync failed. Exiting.
+#
+COMFYUI_PATH=
+LORA_CACHE_DIR=/workspace/models/loras
+RUNPOD_API_KEY=rpa_supersecret
+QUEUE_API_KEY=qk_supersecret
+"""
+
+
+def _dump_pipeline() -> str:
+    """The real command from start.sh, between `echo "Daemon config:"` and the blank line."""
+    text = START_SH.read_text()
+    m = re.search(r'echo "Daemon config:"\n((?:.*\\\n)*.*\n)', text)
+    assert m, "could not find the config dump in start.sh — has it been restructured?"
+    return m.group(1)
+
+
+def _run(env_text: str) -> str:
+    tmp = pathlib.Path(subprocess.run(["mktemp", "-d"], capture_output=True, text=True)
+                       .stdout.strip())
+    envfile = tmp / ".env"
+    envfile.write_text(env_text)
+    script = f'DAEMON_DIR="{tmp}"\n' + _dump_pipeline()
+    out = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    return out.stdout
+
+
+def test_no_line_greps_as_an_error():
+    """The acceptance criterion: a healthy boot contains no line matching ERROR."""
+    out = _run(FAKE_ENV)
+    offenders = [ln for ln in out.splitlines() if "ERROR" in ln]
+    assert offenders == [], f"config dump still prints ERROR-looking lines: {offenders}"
+
+
+def test_comments_are_stripped_entirely():
+    out = _run(FAKE_ENV)
+    assert "#" not in out, f"comments leaked into the boot log:\n{out}"
+
+
+def test_the_values_all_survive():
+    """Stripping must not cost the thing the dump exists for. COMFYUI_PATH= is included
+    deliberately: an EMPTY value is meaningful here and must still be visible."""
+    out = _run(FAKE_ENV)
+    for key in ("QUEUE_URL", "FRIENDLY_NAME", "ENGINE", "COMFYUI_PATH",
+                "LORA_CACHE_DIR", "RUNPOD_API_KEY", "QUEUE_API_KEY"):
+        assert re.search(rf"^\s*{key}=", out, re.M), f"{key} vanished from the dump"
+
+
+def test_secrets_are_still_redacted():
+    """The comment strip must not have disturbed the redaction it sits in front of."""
+    out = _run(FAKE_ENV)
+    assert "supersecret" not in out
+    assert out.count("<redacted>") == 2


### PR DESCRIPTION
Part of wanly-gpu-daemon#175 (the boot-log half). Pairs with wanly-gpu-daemon#178.

## The bug

`start.sh` writes the daemon `.env` from a heredoc that includes explanatory comments, then dumps the resolved file so a parity problem is visible early. The comments went with it — and the comment above `COMFYUI_PATH` **quoted the very log lines it was explaining**:

```
ERROR Resource rife49.pth: download failed ... HTTP 404
ERROR Resource sync failed. Exiting.
```

So every healthy boot printed two lines that grep as `ERROR` — indented and `#`-prefixed, but otherwise indistinguishable from the failure they described. One was read as a live failure during a routine daemon restart today. That misread is what filed the ticket.

## Fix

The dump strips comment and blank lines before redacting:

```
before                                   after
  ENGINE=ltx                               ENGINE=ltx
  # EMPTY on purpose. With a path set...   COMFYUI_PATH=
  #                                        LORA_CACHE_DIR=/workspace/models/loras
  #     ERROR Resource rife49.pth: ...     RUNPOD_API_KEY=<redacted>
  #     ERROR Resource sync failed. ...    QUEUE_API_KEY=<redacted>
  #
  COMFYUI_PATH=
  ...
```

It exists to show resolved **values**; the reasoning belongs in the file. Empty values still print — `COMFYUI_PATH=` is meaningful *because* it's empty.

The `COMFYUI_PATH` comment itself loses the pasted log output and the resource-sync half, which is gone as of wanly-gpu-daemon#178. The node check is now the only reason the path stays empty.

## Tests

Four, and they **extract the pipeline from `start.sh` and run it** rather than restating it — a copy would pass while the real dump regressed, which is precisely the shape of this bug. They cover: no line greps as ERROR, no `#` survives, every value survives (including the empty one), and the secret redaction still works.

Verified they fail when the comment strip is removed. `pytest tests/` — **46 passed**.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J