### PR TITLE
deploy: converge the long-lived worker on :latest, never mid-render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.pyc
 __pycache__/
 .env
+
+# Carries the queue API key — never commit (see deploy/README.md)
+deploy/worker.env

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,66 @@
+# Deploying a long-lived worker
+
+For a box we own and keep running — today the 3090. RunPod pods do not use any of this: the
+API creates them from `:latest` with `runpod_client.worker_env()`, so they are current by
+construction.
+
+## Why this directory exists
+
+There are two independent update channels:
+
+| what | updates on |
+|---|---|
+| the daemon | container **restart** — `start.sh` clones `wanly-gpu-daemon` from `main` at boot |
+| `start.sh`, `download_models.sh`, the engine | image **pull + recreate** |
+
+A pod is recreated every time it launches, so it gets both. A long-lived container only ever
+gets the first, because `docker restart` reuses its image by design. That is how the 3090 came
+to run a 37-hour-old image and a 14-hour-old daemon while a pod ran current code, and produce
+a different result from the same queue (#72).
+
+## First install
+
+```bash
+git clone https://github.com/DavidJBarnes/wanly-gpu-docker.git ~/wanly-gpu-docker
+cd ~/wanly-gpu-docker/deploy
+cp worker.env.example worker.env
+$EDITOR worker.env          # QUEUE_API_KEY and the host paths
+./run-worker.sh
+```
+
+## Keeping it current
+
+```bash
+sudo cp wanly-worker-update.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now wanly-worker-update.timer
+```
+
+`update-worker.sh` pulls `:latest`, compares its digest against the digest the running
+container was created from, and recreates only if they differ **and** the engine reports
+nothing in flight. It exits 0 when it decides not to act, so a non-zero exit in the journal is
+a real failure.
+
+Check on it with:
+
+```bash
+systemctl list-timers wanly-worker-update.timer
+journalctl -u wanly-worker-update.service -n 50
+```
+
+## Rollback
+
+`run-worker.sh` honours `IMAGE`, so pinning an older build is:
+
+```bash
+IMAGE=davidjbarnes/wanly-gpu-docker:<sha> ./run-worker.sh
+```
+
+Re-enable the timer afterwards or it will pull `:latest` back over the pin at the next tick.
+
+## What it will never do
+
+Recreate mid-render. A render is 10-13 minutes and interrupting one loses the work and leaves
+the segment to be reclaimed by the stale-heartbeat path — costing more than the drift it fixes.
+An unreachable engine counts as busy, because a box that is mid-boot must not be interrupted
+either.

--- a/deploy/run-worker.sh
+++ b/deploy/run-worker.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Create (or recreate) the long-lived worker container on a box we own — today the 3090.
+#
+# WHY THIS EXISTS AS A FILE
+#     A RunPod pod is created from :latest every time, so it is always current on both update
+#     channels: the image, and the daemon that start.sh clones from main at boot. A long-lived
+#     container is only current on the second one -- `docker restart` reuses the image by
+#     design. The 3090 therefore drifted to a 37-hour-old image and a 14-hour-old daemon while
+#     a pod ran tonight's code, and the two produced different results from the same queue
+#     (wanly-gpu-docker#72).
+#
+#     Nobody recreated it because the `docker run` existed only in one shell's history.
+#     Reproducing it from memory is exactly the kind of thing that gets a mount or a port
+#     wrong, so it lives here instead.
+#
+# SAFE TO RE-RUN. It stops and removes the existing container first, so this is also the
+# rollback path: point IMAGE at an older tag and run it again.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${WORKER_ENV:-$HERE/worker.env}"
+[ -f "$ENV_FILE" ] || { echo "!! no $ENV_FILE — copy worker.env.example and fill it in"; exit 1; }
+# shellcheck disable=SC1090
+set -a; . "$ENV_FILE"; set +a
+
+IMAGE="${IMAGE:-davidjbarnes/wanly-gpu-docker:latest}"
+NAME="${NAME:-wanly-ltx}"
+
+: "${QUEUE_API_KEY:?set QUEUE_API_KEY in $ENV_FILE}"
+: "${FRIENDLY_NAME:?set FRIENDLY_NAME in $ENV_FILE}"
+
+for d in "$JOBS_DIR" "$MODELS_DIR"; do
+    [ -d "$d" ] || { echo "!! $d does not exist — refusing to create a worker with a broken mount"; exit 1; }
+done
+
+echo "recreating $NAME from $IMAGE"
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+
+# COMFYUI_PATH is EMPTY on purpose — see the note in start.sh. With a path set the daemon
+# takes ownership of ComfyUI's custom nodes, which breaks an LTX worker.
+docker run -d \
+    --name "$NAME" \
+    --restart unless-stopped \
+    --gpus all \
+    -p "${COMFY_HOST_PORT:-8191}:8188" \
+    -p "${ENGINE_HOST_PORT:-8190}:8190" \
+    -v "$JOBS_DIR:/jobs" \
+    -v "$RECIPES_DIR:/opt/engine/recipes:ro" \
+    -v "$MODELS_DIR:/workspace/models:ro" \
+    -v "$MODELS_DIR/loras:/workspace/models/loras" \
+    -e "FRIENDLY_NAME=$FRIENDLY_NAME" \
+    -e "ENGINE=ltx" \
+    -e "QUEUE_URL=$QUEUE_URL" \
+    -e "QUEUE_API_KEY=$QUEUE_API_KEY" \
+    -e "LTX_ENGINE_URL=http://127.0.0.1:8190" \
+    -e "COMFYUI_URL=http://127.0.0.1:8188" \
+    -e "COMFYUI_PATH=" \
+    -e "LORA_CACHE_DIR=/workspace/models/loras" \
+    "$IMAGE"
+
+echo "started: $(docker inspect -f '{{.Id}}' "$NAME" | cut -c1-12) on $(docker inspect -f '{{.Image}}' "$NAME" | cut -c8-19)"
+echo "follow the boot with: docker logs -f $NAME"

--- a/deploy/update-worker.sh
+++ b/deploy/update-worker.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Converge a long-lived worker on :latest, but never mid-render (wanly-gpu-docker#72).
+#
+# Run from a timer. Does nothing at all unless the published image has actually changed, so
+# it is cheap to run often.
+#
+# WHY IDLE MATTERS MORE THAN FRESHNESS
+#     A render is 10-13 minutes (measured: 613s and 759s on the 3090). Recreating the
+#     container mid-render throws that work away, and the segment is then reclaimed by the
+#     stale-heartbeat path -- so an eager updater costs more than the drift it fixes. This
+#     checks the worker is not processing and, if it is, exits and leaves the next run to it.
+#
+# WHY IT COMPARES DIGESTS, NOT TAGS
+#     :latest is a moving pointer. "Am I on latest?" is only answerable by comparing the
+#     digest the container was created from against the digest the tag resolves to NOW.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE="${IMAGE:-davidjbarnes/wanly-gpu-docker:latest}"
+NAME="${NAME:-wanly-ltx}"
+
+log() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $*"; }
+
+if ! docker inspect "$NAME" >/dev/null 2>&1; then
+    log "no container named $NAME — creating it"
+    exec "$HERE/run-worker.sh"
+fi
+
+running_image=$(docker inspect -f '{{.Image}}' "$NAME")
+
+log "pulling $IMAGE"
+docker pull -q "$IMAGE" >/dev/null
+latest_image=$(docker image inspect "$IMAGE" -f '{{.Id}}')
+
+if [ "$running_image" = "$latest_image" ]; then
+    log "already on the published image ($(echo "$latest_image" | cut -c8-19)) — nothing to do"
+    exit 0
+fi
+
+log "image changed: $(echo "$running_image" | cut -c8-19) -> $(echo "$latest_image" | cut -c8-19)"
+
+# Ask the ENGINE whether a render is in flight, not the GPU. A busy GPU could be
+# Automatic1111 on the same box; an idle GPU can still be a claimed segment between diffusion
+# stages. The engine knows what it is running, and it is what recreating the container kills.
+#
+# Asked with `docker exec`, NOT through the published port. The engine binds 127.0.0.1 INSIDE
+# the container, so the -p 8190:8190 mapping resolves to nothing and a host-side curl returns
+# empty -- which, parsed naively, reads as "idle" and would recreate the container mid-render.
+# Verified on the 3090: host curl fails, `docker exec` returns
+# {"queue_depth":0,"running":1,...}.
+busy=$(docker exec "$NAME" curl -sf --max-time 10 http://127.0.0.1:8190/health 2>/dev/null \
+       | python3 -c 'import json,sys;d=json.load(sys.stdin);print((d.get("running") or 0)+(d.get("queue_depth") or 0))' 2>/dev/null || echo unknown)
+
+if [ "$busy" = "unknown" ]; then
+    # Fail SAFE: an unreachable engine is not evidence of idleness. It may be mid-boot, and
+    # recreating then would interrupt model staging.
+    log "could not read the engine's health — assuming busy, will retry next run"
+    exit 0
+fi
+if [ "$busy" != "0" ]; then
+    log "engine reports $busy job(s) in flight — leaving it alone, will retry next run"
+    exit 0
+fi
+
+log "worker is idle — recreating on the new image"
+"$HERE/run-worker.sh"
+log "done"

--- a/deploy/wanly-worker-update.service
+++ b/deploy/wanly-worker-update.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Converge the wanly LTX worker on the published image
+Documentation=https://github.com/DavidJBarnes/wanly-gpu-docker/issues/72
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+# Runs as the user that owns the docker socket and the model tree. Not root: the mounts are
+# under this user's home and a root-created container would write /jobs files they cannot
+# delete.
+User=david
+ExecStart=/home/david/wanly-gpu-docker/deploy/update-worker.sh
+# The script exits 0 when it decides not to act, so a failure here is a real one.
+StandardOutput=journal
+StandardError=journal

--- a/deploy/wanly-worker-update.timer
+++ b/deploy/wanly-worker-update.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Check for a new wanly worker image periodically
+Documentation=https://github.com/DavidJBarnes/wanly-gpu-docker/issues/72
+
+[Timer]
+# Every 30 minutes. The check is a digest comparison after a `docker pull` of an image that is
+# almost always unchanged, so it costs a manifest fetch and nothing else -- there is no reason
+# to be shy about frequency. What SETS the pace is that it can only act while idle: a render
+# is 10-13 minutes, so a 30 minute cadence reliably finds a gap within the hour.
+OnBootSec=10min
+OnUnitActiveSec=30min
+# Do not have every box on the network pull at the same instant after a power cut.
+RandomizedDelaySec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/worker.env.example
+++ b/deploy/worker.env.example
@@ -1,0 +1,20 @@
+# Host-side config for a long-lived worker (the 3090). Copy to deploy/worker.env and fill in.
+# NEVER commit the real file — it carries the queue key.
+#
+# A RunPod pod gets these from the launcher's env dict (wanly-api runpod_client.worker_env).
+# This is the same set for a box that is not launched by the API.
+
+FRIENDLY_NAME=3090.zero
+QUEUE_URL=http://api.wanly22.com:8001
+QUEUE_API_KEY=
+
+# Host paths bind-mounted into the container. The models tree is READ-ONLY on purpose: this
+# box is the source of truth for 217 GB of weights and nothing in the container should be
+# able to modify or delete them.
+JOBS_DIR=/home/david/ltx-jobs
+RECIPES_DIR=/home/david/storyboard-build/ltx-engine/recipes
+MODELS_DIR=/home/david/LTX-2/models
+
+# 8188 is already taken on this host by Automatic1111's neighbour, hence 8191 outside.
+COMFY_HOST_PORT=8191
+ENGINE_HOST_PORT=8190

--- a/tests/test_worker_deploy.py
+++ b/tests/test_worker_deploy.py
@@ -1,0 +1,171 @@
+"""The long-lived worker must converge on :latest, and never mid-render (#72).
+
+The 3090 ran a 37-hour-old image and a 14-hour-old daemon while a RunPod pod ran current
+code, and the two produced different results from the same queue. Nothing detected it; it
+surfaced as a 422 that looked random.
+
+These tests guard the two halves of the fix: that the container spec is complete enough to
+recreate the worker correctly, and that the updater's decision logic is right -- because
+every wrong decision it can make is expensive. Recreating mid-render loses 10-13 minutes and
+leaves a segment to be reclaimed; never recreating leaves the drift in place.
+"""
+import os
+import pathlib
+import shutil
+import stat
+import subprocess
+import textwrap
+
+DEPLOY = pathlib.Path(__file__).parent.parent / "deploy"
+RUN = DEPLOY / "run-worker.sh"
+UPDATE = DEPLOY / "update-worker.sh"
+
+
+class TestTheContainerSpecIsComplete:
+    """Captured from the running 3090 container on 2026-09-06. A missing mount or port does
+    not fail loudly -- the worker boots and then cannot see its models, or the console cannot
+    reach ComfyUI, both of which are diagnosed the slow way."""
+
+    def test_every_captured_mount_is_present(self):
+        s = RUN.read_text()
+        for mount in ("/jobs", "/opt/engine/recipes:ro", "/workspace/models:ro",
+                      "/workspace/models/loras"):
+            assert mount in s, f"run-worker.sh no longer mounts {mount}"
+
+    def test_the_models_tree_stays_read_only(self):
+        """This box is the source of truth for 217 GB of weights. Nothing in the container
+        should be able to modify or delete them."""
+        assert '"$MODELS_DIR:/workspace/models:ro"' in RUN.read_text()
+
+    def test_both_published_ports(self):
+        s = RUN.read_text()
+        assert ":8188" in s and ":8190" in s
+
+    def test_it_survives_a_reboot(self):
+        assert "--restart unless-stopped" in RUN.read_text()
+
+    def test_it_gets_the_gpu(self):
+        assert "--gpus all" in RUN.read_text()
+
+    def test_comfyui_path_is_explicitly_empty(self):
+        """Not merely absent. With a path set the daemon takes ownership of ComfyUI's custom
+        nodes, which breaks an LTX worker -- and an unset variable in the container would let
+        an image default win."""
+        assert '-e "COMFYUI_PATH="' in RUN.read_text()
+
+    def test_the_queue_key_is_required_not_defaulted(self):
+        """A worker that boots without it registers and then claims nothing, which reads as
+        an empty queue."""
+        assert 'QUEUE_API_KEY:?' in RUN.read_text()
+
+
+class TestTheIdleCheck:
+    def test_it_asks_inside_the_container(self):
+        """The engine binds 127.0.0.1 INSIDE the container, so the -p 8190:8190 mapping
+        resolves to nothing. Verified on the 3090: a host-side curl returns empty, which
+        parsed naively reads as "idle" and would recreate the container mid-render. This
+        very nearly shipped."""
+        s = UPDATE.read_text()
+        assert 'docker exec "$NAME" curl' in s, \
+            "the idle check must run inside the container, not against the published port"
+
+
+def _fake_docker(tmp, *, running_image, latest_image, busy):
+    """A `docker` shim covering exactly the calls update-worker.sh makes."""
+    bin_dir = tmp / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    (bin_dir / "docker").write_text(textwrap.dedent(f"""\
+        #!/usr/bin/env bash
+        case "$1 $2" in
+          "inspect wanly-ltx")            echo present; exit 0 ;;
+        esac
+        case "$*" in
+          "inspect -f {{{{.Image}}}} wanly-ltx")  echo "{running_image}"; exit 0 ;;
+          "pull -q "*)                            exit 0 ;;
+          "image inspect "*)                      echo "{latest_image}"; exit 0 ;;
+          *"curl"*)                               echo '{{"queue_depth":0,"running":{busy}}}'; exit 0 ;;
+        esac
+        exit 0
+        """))
+    (bin_dir / "docker").chmod(0o755)
+    # run-worker.sh is replaced: this test is about the DECISION, not the docker run.
+    (bin_dir / "run-worker.sh").write_text("#!/usr/bin/env bash\necho RECREATED\n")
+    (bin_dir / "run-worker.sh").chmod(0o755)
+    return bin_dir
+
+
+def _run(tmp_path, *, running_image, latest_image, busy):
+    bin_dir = _fake_docker(tmp_path, running_image=running_image,
+                           latest_image=latest_image, busy=busy)
+    stage = tmp_path / "deploy"
+    stage.mkdir(exist_ok=True)
+    shutil.copy(UPDATE, stage / "update-worker.sh")
+    shutil.copy(bin_dir / "run-worker.sh", stage / "run-worker.sh")
+    (stage / "run-worker.sh").chmod(0o755)
+    env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}")
+    return subprocess.run(["bash", str(stage / "update-worker.sh")],
+                          capture_output=True, text=True, env=env)
+
+
+class TestTheDecision:
+    SAME = "sha256:aaa"
+    NEW = "sha256:bbb"
+
+    def test_it_does_nothing_when_the_image_has_not_changed(self, tmp_path):
+        """It runs on a timer against an image that is almost always unchanged, so the
+        no-op path is the common one and must be silent and cheap."""
+        r = _run(tmp_path, running_image=self.SAME, latest_image=self.SAME, busy=0)
+        assert r.returncode == 0
+        assert "nothing to do" in r.stdout
+        assert "RECREATED" not in r.stdout
+
+    def test_it_recreates_when_the_image_changed_and_the_worker_is_idle(self, tmp_path):
+        r = _run(tmp_path, running_image=self.SAME, latest_image=self.NEW, busy=0)
+        assert r.returncode == 0
+        assert "RECREATED" in r.stdout, r.stdout
+
+    def test_it_leaves_a_busy_worker_alone(self, tmp_path):
+        """THE one that matters. A render is 10-13 minutes; interrupting it loses the work
+        AND leaves the segment to be reclaimed, costing more than the drift it fixes."""
+        r = _run(tmp_path, running_image=self.SAME, latest_image=self.NEW, busy=1)
+        assert r.returncode == 0
+        assert "RECREATED" not in r.stdout, "recreated the container mid-render"
+        assert "in flight" in r.stdout
+
+    def test_an_unreadable_engine_counts_as_busy(self, tmp_path):
+        """Fail SAFE. An unreachable engine is not evidence of idleness -- it may be
+        mid-boot, and recreating then interrupts model staging."""
+        bin_dir = _fake_docker(tmp_path, running_image=self.SAME,
+                               latest_image=self.NEW, busy=0)
+        (bin_dir / "docker").write_text(textwrap.dedent(f"""\
+            #!/usr/bin/env bash
+            case "$*" in
+              "inspect -f {{{{.Image}}}} wanly-ltx")  echo "{self.SAME}"; exit 0 ;;
+              "pull -q "*)                            exit 0 ;;
+              "image inspect "*)                      echo "{self.NEW}"; exit 0 ;;
+              *"curl"*)                               exit 7 ;;
+            esac
+            exit 0
+            """))
+        (bin_dir / "docker").chmod(0o755)
+        stage = tmp_path / "deploy"; stage.mkdir(exist_ok=True)
+        shutil.copy(UPDATE, stage / "update-worker.sh")
+        shutil.copy(bin_dir / "run-worker.sh", stage / "run-worker.sh")
+        (stage / "run-worker.sh").chmod(0o755)
+        env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}")
+        r = subprocess.run(["bash", str(stage / "update-worker.sh")],
+                           capture_output=True, text=True, env=env)
+        assert "RECREATED" not in r.stdout
+        assert "assuming busy" in r.stdout
+
+
+def test_the_scripts_are_executable():
+    for p in (RUN, UPDATE):
+        assert os.stat(p).st_mode & stat.S_IXUSR, f"{p.name} is not executable"
+
+
+def test_no_secret_is_committed():
+    """worker.env carries the queue key and must never be in the repo."""
+    assert not (DEPLOY / "worker.env").exists()
+    assert "QUEUE_API_KEY=" in (DEPLOY / "worker.env.example").read_text()
+    assert (DEPLOY / "worker.env.example").read_text().count("QUEUE_API_KEY=\n") == 1


### PR DESCRIPTION
Part of #72. This is the "make it converge" half; reporting what a worker runs is the remaining half.

## The problem, concretely

The 3090 and a RunPod pod ran different code for 14 hours and nothing said so. It surfaced as a 422 that looked random — the pod fetched `plora_sulfter_...` fine at 05:43:49, the 3090 couldn't.

| what | updates on | 3090 was |
|---|---|---|
| daemon | container **restart** (git clone from `main`) | `6786f86`, 14h old |
| `start.sh`, downloader, engine | image **pull + recreate** | `f3833b1f`, built Sept 4 |

A pod is **created** from `:latest` each launch, so it gets both channels. A long-lived container only ever gets the first — `docker restart` reuses its image by design. Restarting the 3090 tonight moved the daemon to current and left the image untouched, which is exactly right and exactly the problem.

## What's here

**`deploy/run-worker.sh`** — the `docker run` as code. Captured from the running container, not reconstructed from memory: four mounts (models read-only, because that box holds 217 GB of weights nothing in the container should be able to delete), two ports, `--gpus all`, `--restart unless-stopped`, `COMFYUI_PATH` explicitly empty. Secrets live in a gitignored `deploy/worker.env`.

Nobody recreated the container because that invocation existed only in one shell's history. That's the actual reason it drifted.

**`deploy/update-worker.sh`** — pulls `:latest`, compares its digest against the digest the running container was created from, recreates only if they differ **and** the engine reports nothing in flight. Digests rather than tags, because `:latest` is a moving pointer.

**A systemd timer**, every 30 minutes. The pace is set by having to wait for idle, not the cost of checking — the check is a manifest fetch on an image that's almost always unchanged.

## The bug I nearly shipped

The idle check originally curled `http://127.0.0.1:8190/health` on the host, via the published port. **The engine binds `127.0.0.1` inside the container**, so that mapping resolves to nothing:

```
from the HOST          NOT reachable
docker exec ... curl   {"queue_depth":0,"running":1,...}
```

A host curl returns empty, which parsed naively reads as *idle* — so the updater would have recreated the container mid-render, every time. Caught by testing against the live box before merging. There's now a test pinning `docker exec`.

## Why idle beats fresh

A render is 10–13 minutes (measured: 613s and 759s tonight). Recreating mid-render loses the work *and* leaves the segment to be reclaimed by the stale-heartbeat path — more expensive than the drift it fixes. An unreachable engine counts as **busy**, because it may be mid-boot and interrupting model staging is worse again.

## Tests

14, driving the real script with a fake `docker` across all four decisions: unchanged image → no-op; changed + idle → recreate; changed + busy → leave alone; engine unreadable → assume busy. Plus the spec completeness checks (a dropped mount doesn't fail loudly — the worker boots and then can't see its models).

Verified they fail both when the host-curl bug is reintroduced and when the busy guard is removed.

`pytest tests/` — **60 passed**.

## Deploying it

Not automatic — this needs installing on the 3090 once (`deploy/README.md` has the steps). I'll do that and confirm the timer fires.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J