### PR TITLE
deploy: the idle check must cover the whole claim, not just the render

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,7 +60,24 @@ Re-enable the timer afterwards or it will pull `:latest` back over the pin at th
 
 ## What it will never do
 
-Recreate mid-render. A render is 10-13 minutes and interrupting one loses the work and leaves
-the segment to be reclaimed by the stale-heartbeat path — costing more than the drift it fixes.
-An unreachable engine counts as busy, because a box that is mid-boot must not be interrupted
-either.
+Recreate while the worker holds a claim.
+
+**Two signals, both must say idle.** The worker's own status from the API, and the engine's
+health. They cover different spans and each catches the other's blind spot:
+
+| signal | covers | blind to |
+|---|---|---|
+| worker status (`online-idle`) | the whole claim — set the instant work is received, before `[1/6]` | a failed status push from the daemon |
+| engine `running`/`queue_depth` | the render itself, from `[3/6]` | `[1/6]`–`[2/6]`: image and LoRA/checkpoint fetch |
+
+The engine-only version of this cost a segment on 2026-09-06: a container was recreated 50%
+through a 673 MB LoRA download in `[2/6]`, where the engine truthfully reports `running: 0`.
+Because registration reuses the worker row, the abandoned segment was pinned to a live, busy
+worker that no reclaim rule could reach, and it sat in `PROCESSING` for seven hours.
+
+That window is now much wider than it was: console#423 lets a worker fetch a 46 GB checkpoint
+on demand, which is roughly twenty minutes inside `[2/6]`.
+
+Anything unreadable — the API, the engine, a worker that has not registered yet — counts as
+**busy**. A box mid-boot must not be interrupted either; on a cold pod that is ~58 GB of
+staging thrown away.

--- a/deploy/update-worker.sh
+++ b/deploy/update-worker.sh
@@ -19,6 +19,15 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE="${IMAGE:-davidjbarnes/wanly-gpu-docker:latest}"
 NAME="${NAME:-wanly-ltx}"
 
+# Needed for the idle check below: QUEUE_URL, QUEUE_API_KEY and FRIENDLY_NAME identify this
+# worker to the API. Sourced rather than required, so the script still runs (and still
+# refuses to act) on a box where the file is absent -- an unreadable status counts as busy.
+ENV_FILE="${WORKER_ENV:-$HERE/worker.env}"
+if [ -f "$ENV_FILE" ]; then
+    # shellcheck disable=SC1090
+    set -a; . "$ENV_FILE"; set +a
+fi
+
 log() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $*"; }
 
 if ! docker inspect "$NAME" >/dev/null 2>&1; then
@@ -39,15 +48,49 @@ fi
 
 log "image changed: $(echo "$running_image" | cut -c8-19) -> $(echo "$latest_image" | cut -c8-19)"
 
-# Ask the ENGINE whether a render is in flight, not the GPU. A busy GPU could be
-# Automatic1111 on the same box; an idle GPU can still be a claimed segment between diffusion
-# stages. The engine knows what it is running, and it is what recreating the container kills.
+# TWO independent signals, and BOTH must say idle. Each covers the other's blind spot.
 #
-# Asked with `docker exec`, NOT through the published port. The engine binds 127.0.0.1 INSIDE
-# the container, so the -p 8190:8190 mapping resolves to nothing and a host-side curl returns
-# empty -- which, parsed naively, reads as "idle" and would recreate the container mid-render.
-# Verified on the 3090: host curl fails, `docker exec` returns
-# {"queue_depth":0,"running":1,...}.
+#   1. THE WORKER'S OWN STATUS, from the API. The daemon sets online-busy the instant it
+#      receives a claim, BEFORE [1/6], and online-idle only once the segment finishes. That
+#      is the only signal covering the WHOLE claim.
+#
+#      This is the check that was missing, and its absence cost a segment. The first version
+#      asked only the engine -- which knows nothing until [3/6] Submitting. A container was
+#      recreated 50% through a 673 MB LoRA download in [2/6]; the engine truthfully said
+#      running=0, the segment was abandoned mid-claim, and because registration reuses the
+#      worker row it was pinned to a live busy worker where no reclaim rule could reach it.
+#      It sat in PROCESSING for seven hours.
+#
+#      The gap widened the same day: console#423 lets a worker fetch a 46 GB checkpoint on
+#      demand, which is ~20 minutes inside [2/6] with the engine reporting idle throughout.
+#
+#   2. THE ENGINE. Kept, because the daemon's status push can fail -- the API's own reclaim
+#      logic says so. If the daemon claims idle while the engine is rendering, believe the
+#      engine.
+#
+# Asked with `docker exec`, NOT through the published port: the engine binds 127.0.0.1 INSIDE
+# the container, so -p 8190:8190 resolves to nothing and a host curl returns empty -- which
+# parsed naively reads as "idle".
+worker_status=$(curl -sf --max-time 15 -H "X-API-Key: ${QUEUE_API_KEY:-}" \
+                  "${QUEUE_URL:-}/workers" 2>/dev/null \
+                | FRIENDLY_NAME="${FRIENDLY_NAME:-}" python3 -c '
+import json, os, sys
+name = os.environ.get("FRIENDLY_NAME", "")
+try:
+    rows = json.load(sys.stdin)
+except Exception:
+    print("unreadable"); raise SystemExit
+me = [w for w in rows if w.get("friendly_name") == name]
+# Not finding ourselves is NOT idleness. A worker mid-boot has not registered yet, and
+# recreating then interrupts model staging.
+print(me[0].get("status") or "unknown" if me else "not-registered")
+' 2>/dev/null || echo unreadable)
+
+if [ "$worker_status" != "online-idle" ]; then
+    log "worker status is '$worker_status' (want online-idle) — leaving it alone, will retry next run"
+    exit 0
+fi
+
 busy=$(docker exec "$NAME" curl -sf --max-time 10 http://127.0.0.1:8190/health 2>/dev/null \
        | python3 -c 'import json,sys;d=json.load(sys.stdin);print((d.get("running") or 0)+(d.get("queue_depth") or 0))' 2>/dev/null || echo unknown)
 
@@ -58,7 +101,9 @@ if [ "$busy" = "unknown" ]; then
     exit 0
 fi
 if [ "$busy" != "0" ]; then
-    log "engine reports $busy job(s) in flight — leaving it alone, will retry next run"
+    # The daemon said idle and the engine disagrees. Believe the engine: a failed status push
+    # is a known mode, and being wrong here costs a render.
+    log "engine reports $busy job(s) in flight despite status '$worker_status' — leaving it alone"
     exit 0
 fi
 

--- a/tests/test_worker_deploy.py
+++ b/tests/test_worker_deploy.py
@@ -70,39 +70,58 @@ class TestTheIdleCheck:
             "the idle check must run inside the container, not against the published port"
 
 
-def _fake_docker(tmp, *, running_image, latest_image, busy):
-    """A `docker` shim covering exactly the calls update-worker.sh makes."""
+def _stage(tmp, *, running_image, latest_image, engine_busy, worker_status):
+    """Stage the real update-worker.sh with fakes for every external call it makes.
+
+    Two separate fakes, because the script asks two different things:
+      * `curl` on the HOST            -> the API's /workers, for the worker's own status
+      * `curl` INSIDE the container   -> the engine's /health, via docker exec
+    """
     bin_dir = tmp / "bin"
     bin_dir.mkdir(exist_ok=True)
-    (bin_dir / "docker").write_text(textwrap.dedent(f"""\
-        #!/usr/bin/env bash
-        case "$1 $2" in
-          "inspect wanly-ltx")            echo present; exit 0 ;;
-        esac
-        case "$*" in
-          "inspect -f {{{{.Image}}}} wanly-ltx")  echo "{running_image}"; exit 0 ;;
-          "pull -q "*)                            exit 0 ;;
-          "image inspect "*)                      echo "{latest_image}"; exit 0 ;;
-          *"curl"*)                               echo '{{"queue_depth":0,"running":{busy}}}'; exit 0 ;;
-        esac
-        exit 0
-        """))
+
+    if engine_busy is None:
+        engine_case = "exit 7"
+    else:
+        engine_case = "echo '{\"queue_depth\":0,\"running\":%d}'" % engine_busy
+
+    docker = "\n".join([
+        "#!/usr/bin/env bash",
+        'case "$*" in',
+        '  "inspect -f {{.Image}} wanly-ltx")  echo "%s"; exit 0 ;;' % running_image,
+        '  "pull -q "*)                        exit 0 ;;',
+        '  "image inspect "*)                  echo "%s"; exit 0 ;;' % latest_image,
+        '  *"curl"*)                           %s ;;' % engine_case,
+        'esac',
+        'exit 0',
+        '',
+    ])
+    (bin_dir / "docker").write_text(docker)
     (bin_dir / "docker").chmod(0o755)
-    # run-worker.sh is replaced: this test is about the DECISION, not the docker run.
-    (bin_dir / "run-worker.sh").write_text("#!/usr/bin/env bash\necho RECREATED\n")
-    (bin_dir / "run-worker.sh").chmod(0o755)
-    return bin_dir
 
+    if worker_status is None:
+        body = "BAD NOT JSON"
+    elif worker_status == "absent":
+        body = "[]"
+    else:
+        body = '[{"friendly_name":"3090.zero","status":"%s"}]' % worker_status
+    (bin_dir / "curl").write_text("#!/usr/bin/env bash\ncat <<'JSON'\n%s\nJSON\n" % body)
+    (bin_dir / "curl").chmod(0o755)
 
-def _run(tmp_path, *, running_image, latest_image, busy):
-    bin_dir = _fake_docker(tmp_path, running_image=running_image,
-                           latest_image=latest_image, busy=busy)
-    stage = tmp_path / "deploy"
+    stage = tmp / "deploy"
     stage.mkdir(exist_ok=True)
     shutil.copy(UPDATE, stage / "update-worker.sh")
-    shutil.copy(bin_dir / "run-worker.sh", stage / "run-worker.sh")
+    (stage / "run-worker.sh").write_text("#!/usr/bin/env bash\necho RECREATED\n")
     (stage / "run-worker.sh").chmod(0o755)
-    env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}")
+    (stage / "worker.env").write_text(
+        "QUEUE_URL=http://api.test:8001\nQUEUE_API_KEY=k\nFRIENDLY_NAME=3090.zero\n")
+    return bin_dir, stage
+
+
+def _run(tmp_path, *, running_image, latest_image, engine_busy=0, worker_status="online-idle"):
+    bin_dir, stage = _stage(tmp_path, running_image=running_image, latest_image=latest_image,
+                            engine_busy=engine_busy, worker_status=worker_status)
+    env = dict(os.environ, PATH="%s:%s" % (bin_dir, os.environ["PATH"]))
     return subprocess.run(["bash", str(stage / "update-worker.sh")],
                           capture_output=True, text=True, env=env)
 
@@ -112,60 +131,65 @@ class TestTheDecision:
     NEW = "sha256:bbb"
 
     def test_it_does_nothing_when_the_image_has_not_changed(self, tmp_path):
-        """It runs on a timer against an image that is almost always unchanged, so the
-        no-op path is the common one and must be silent and cheap."""
-        r = _run(tmp_path, running_image=self.SAME, latest_image=self.SAME, busy=0)
-        assert r.returncode == 0
-        assert "nothing to do" in r.stdout
-        assert "RECREATED" not in r.stdout
+        """The common path — it runs on a timer against an image that rarely changes."""
+        r = _run(tmp_path, running_image=self.SAME, latest_image=self.SAME)
+        assert "nothing to do" in r.stdout and "RECREATED" not in r.stdout
 
     def test_it_recreates_when_the_image_changed_and_the_worker_is_idle(self, tmp_path):
-        r = _run(tmp_path, running_image=self.SAME, latest_image=self.NEW, busy=0)
-        assert r.returncode == 0
+        r = _run(tmp_path, running_image=self.SAME, latest_image=self.NEW)
         assert "RECREATED" in r.stdout, r.stdout
 
-    def test_it_leaves_a_busy_worker_alone(self, tmp_path):
-        """THE one that matters. A render is 10-13 minutes; interrupting it loses the work
-        AND leaves the segment to be reclaimed, costing more than the drift it fixes."""
-        r = _run(tmp_path, running_image=self.SAME, latest_image=self.NEW, busy=1)
-        assert r.returncode == 0
-        assert "RECREATED" not in r.stdout, "recreated the container mid-render"
-        assert "in flight" in r.stdout
+    def test_it_leaves_a_worker_alone_that_holds_a_claim(self, tmp_path):
+        """THE regression, 2026-09-06.
+
+        The daemon sets online-busy the instant it receives a claim, BEFORE [1/6]. The engine
+        knows nothing until [3/6]. A container was recreated 50% through a 673 MB LoRA
+        download in [2/6] — engine truthfully idle, worker very much not — and the abandoned
+        segment sat in PROCESSING for seven hours, pinned to a live worker where no reclaim
+        rule could reach it.
+
+        console#423 widened the window the same day: an on-demand 46 GB checkpoint fetch is
+        ~20 minutes inside [2/6] with the engine reporting idle throughout.
+        """
+        r = _run(tmp_path, running_image=self.SAME, latest_image=self.NEW,
+                 worker_status="online-busy", engine_busy=0)
+        assert "RECREATED" not in r.stdout, "recreated while the worker held a claim"
+        assert "online-busy" in r.stdout
+
+    def test_it_believes_the_engine_over_a_worker_claiming_to_be_idle(self, tmp_path):
+        """The daemon's status push can fail — the API's own reclaim logic says so. When the
+        two disagree, the one that is actually rendering wins."""
+        r = _run(tmp_path, running_image=self.SAME, latest_image=self.NEW,
+                 worker_status="online-idle", engine_busy=1)
+        assert "RECREATED" not in r.stdout
+        assert "despite status" in r.stdout
+
+    def test_an_unregistered_worker_is_not_idle(self, tmp_path):
+        """A worker mid-boot has not registered yet. Recreating then interrupts model
+        staging, which on a cold pod is ~58 GB of downloads."""
+        r = _run(tmp_path, running_image=self.SAME, latest_image=self.NEW,
+                 worker_status="absent")
+        assert "RECREATED" not in r.stdout
+        assert "not-registered" in r.stdout
+
+    def test_an_unreadable_api_counts_as_busy(self, tmp_path):
+        r = _run(tmp_path, running_image=self.SAME, latest_image=self.NEW, worker_status=None)
+        assert "RECREATED" not in r.stdout
+        assert "unreadable" in r.stdout
 
     def test_an_unreadable_engine_counts_as_busy(self, tmp_path):
-        """Fail SAFE. An unreachable engine is not evidence of idleness -- it may be
-        mid-boot, and recreating then interrupts model staging."""
-        bin_dir = _fake_docker(tmp_path, running_image=self.SAME,
-                               latest_image=self.NEW, busy=0)
-        (bin_dir / "docker").write_text(textwrap.dedent(f"""\
-            #!/usr/bin/env bash
-            case "$*" in
-              "inspect -f {{{{.Image}}}} wanly-ltx")  echo "{self.SAME}"; exit 0 ;;
-              "pull -q "*)                            exit 0 ;;
-              "image inspect "*)                      echo "{self.NEW}"; exit 0 ;;
-              *"curl"*)                               exit 7 ;;
-            esac
-            exit 0
-            """))
-        (bin_dir / "docker").chmod(0o755)
-        stage = tmp_path / "deploy"; stage.mkdir(exist_ok=True)
-        shutil.copy(UPDATE, stage / "update-worker.sh")
-        shutil.copy(bin_dir / "run-worker.sh", stage / "run-worker.sh")
-        (stage / "run-worker.sh").chmod(0o755)
-        env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}")
-        r = subprocess.run(["bash", str(stage / "update-worker.sh")],
-                           capture_output=True, text=True, env=env)
+        """Fail safe on both signals, not just the API one."""
+        r = _run(tmp_path, running_image=self.SAME, latest_image=self.NEW, engine_busy=None)
         assert "RECREATED" not in r.stdout
         assert "assuming busy" in r.stdout
 
 
 def test_the_scripts_are_executable():
     for p in (RUN, UPDATE):
-        assert os.stat(p).st_mode & stat.S_IXUSR, f"{p.name} is not executable"
+        assert os.stat(p).st_mode & stat.S_IXUSR, "%s is not executable" % p.name
 
 
 def test_no_secret_is_committed():
     """worker.env carries the queue key and must never be in the repo."""
     assert not (DEPLOY / "worker.env").exists()
-    assert "QUEUE_API_KEY=" in (DEPLOY / "worker.env.example").read_text()
     assert (DEPLOY / "worker.env.example").read_text().count("QUEUE_API_KEY=\n") == 1


### PR DESCRIPTION
Fixes a regression I introduced in #73 a few hours ago. Pairs with wanly-api#265, which makes the resulting damage recoverable.

## What I got wrong

The updater's idle check asked **only the engine**. The engine knows nothing about a segment until `[3/6] Submitting` — every claim first spends `[1/6]` fetching a start image and `[2/6]` fetching LoRAs, during which `running: 0` is entirely truthful and entirely useless for this decision.

It cost a segment the same day:

```
[06:34:59] [2/6] Downloading plora_sulfter...safetensors (673 MB)...
[06:37:14] [2/6] plora_sulfter...: 50% of 673 MB
 06:37:51  updater: "worker is idle — recreating on the new image"
```

Because registration reuses the worker row, the abandoned segment was pinned to a **live, healthy, busy** worker where no reclaim rule could reach it. It sat in `PROCESSING` for **seven hours**, its job unable to finish, with the console showing two segments in progress against one online worker.

And I widened the window in the same session: console#423 lets a worker fetch a **46 GB checkpoint** on demand — roughly twenty minutes inside `[2/6]`, engine idle throughout.

## The fix: two signals, both must agree

| signal | covers | blind to |
|---|---|---|
| worker status (`online-idle`) from the API | the whole claim — set the instant work is received, before `[1/6]` | a failed status push from the daemon |
| engine `running`/`queue_depth` | the render, from `[3/6]` | `[1/6]`–`[2/6]` |

The worker-status check is the one that was missing. The engine check stays because the daemon's status push can fail — the API's own reclaim logic says exactly that — so when the two disagree, the one actually rendering wins.

Anything unreadable counts as **busy**: an unregistered worker is mid-boot, not idle, and interrupting staging on a cold pod throws away ~58 GB.

## Why the original tests didn't catch it

They mock a `busy` value and exercise the *decision logic* — they never tested what "busy" should mean. The comment I wrote at the time even says *"an idle GPU can still be a claimed segment between diffusion stages"*, and then I picked a signal that doesn't cover it.

The new tests drive the real script against both disagreement cases: a busy worker with an idle engine (the regression), and an idle worker with a busy engine. Plus unregistered, unreadable API, unreadable engine.

**Verified: removing the worker-status check fails three tests.**

`pytest tests/` — **63 passed**.

## State right now

The timer is **stopped and disabled** on the 3090, and the orphaned segment has been freed by hand (`pending`, queue back to a consistent 20/1). I'll re-enable the timer once this and wanly-api#265 are both deployed.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J