### PR TITLE
Give the image an identity, and actually pass it at build time

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -40,5 +40,11 @@ jobs:
             davidjbarnes/wanly-gpu-docker:${{ github.sha }}
             davidjbarnes/wanly22-runpod:latest
             davidjbarnes/wanly22-runpod:${{ github.sha }}
+          # Without this the image reports GIT_SHA=unknown, which is what every build
+          # before #72 did -- start.sh has printed "image build: unknown" on every boot since
+          # the line was added, and the daemon now reports the same value upstream so two
+          # workers on different images can be told apart.
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,8 +145,19 @@ COPY download_models.sh /app/download_models.sh
 COPY start.sh /app/start.sh
 RUN chmod +x /app/start.sh /app/download_models.sh && mkdir -p /jobs /workspace/logs
 
+# The commit this IMAGE was built from. Distinct from the daemon's commit, which is cloned
+# from main at every container boot -- the two drift separately and `docker restart` moves
+# only the daemon (wanly-gpu-docker#72).
+#
+# The build workflow must pass --build-arg GIT_SHA. Without it this defaults to "unknown",
+# which is exactly what every image published before #72 reports: start.sh has printed
+# "image build: ${GIT_SHA:-unknown}" since it was added, and it has always said unknown.
 ARG GIT_SHA=unknown
 ENV GIT_SHA=$GIT_SHA
+# Same value under the name the daemon reports upstream. Named rather than reusing GIT_SHA
+# directly so the heartbeat field cannot be confused with any other component's sha inside an
+# image that also clones ComfyUI and five node packs.
+ENV WANLY_IMAGE_REF=$GIT_SHA
 
 EXPOSE 8188 8190 22
 CMD ["/app/start.sh"]

--- a/tests/test_image_ref.py
+++ b/tests/test_image_ref.py
@@ -1,0 +1,54 @@
+"""The image must be able to say which commit built it (wanly-gpu-docker#72).
+
+start.sh has printed `image build: ${GIT_SHA:-unknown}` since the line was added, and it has
+always said **unknown** -- the ARG existed and the build never passed it. So an image had no
+identity at all, which is half of why two workers running different code went unnoticed for
+14 hours: even reading the boot log told you nothing.
+
+The daemon now reports WANLY_IMAGE_REF upstream, so this value stops being decorative.
+"""
+import pathlib
+import re
+
+import yaml
+
+ROOT = pathlib.Path(__file__).parent.parent
+DOCKERFILE = ROOT / "Dockerfile"
+WORKFLOW = ROOT / ".github/workflows/build-push.yml"
+
+
+def _build_step():
+    d = yaml.safe_load(WORKFLOW.read_text())
+    for job in d["jobs"].values():
+        for step in job["steps"]:
+            if "build-push-action" in str(step.get("uses", "")):
+                return step
+    raise AssertionError("no docker build step in the workflow")
+
+
+def test_the_build_passes_the_commit():
+    """THE fix. Without this the ARG defaults to 'unknown' and the whole chain is inert."""
+    args = _build_step()["with"].get("build-args", "")
+    assert "GIT_SHA=" in args, "the build does not pass GIT_SHA; the image cannot identify itself"
+    assert "github.sha" in args, "GIT_SHA must come from the commit, not a literal"
+
+
+def test_the_dockerfile_exposes_it_under_the_name_the_daemon_reads():
+    """daemon/build_identity.py reads WANLY_IMAGE_REF. A rename on either side silently
+    returns the field to null, which from the API is indistinguishable from an older daemon
+    that cannot report at all."""
+    s = DOCKERFILE.read_text()
+    assert re.search(r"^ENV WANLY_IMAGE_REF=\$GIT_SHA", s, re.M), \
+        "WANLY_IMAGE_REF is not set from GIT_SHA"
+
+
+def test_it_still_defaults_rather_than_failing_the_build():
+    """A local `docker build` with no --build-arg must still work. An image that refuses to
+    build without CI is worse than one that says 'unknown'."""
+    assert re.search(r"^ARG GIT_SHA=unknown", DOCKERFILE.read_text(), re.M)
+
+
+def test_the_boot_log_still_prints_it():
+    """The line existed before this change and was always 'unknown'. It is the first place
+    anyone looks when two workers disagree, so it must survive."""
+    assert "image build:" in (ROOT / "start.sh").read_text()

--- a/tests/test_image_ref.py
+++ b/tests/test_image_ref.py
@@ -10,25 +10,27 @@ The daemon now reports WANLY_IMAGE_REF upstream, so this value stops being decor
 import pathlib
 import re
 
-import yaml
-
 ROOT = pathlib.Path(__file__).parent.parent
 DOCKERFILE = ROOT / "Dockerfile"
 WORKFLOW = ROOT / ".github/workflows/build-push.yml"
 
 
-def _build_step():
-    d = yaml.safe_load(WORKFLOW.read_text())
-    for job in d["jobs"].values():
-        for step in job["steps"]:
-            if "build-push-action" in str(step.get("uses", "")):
-                return step
-    raise AssertionError("no docker build step in the workflow")
+def _build_args_block() -> str:
+    """The build-args block from the docker build step.
+
+    Read with a regex rather than a YAML parser: every other test in this repo is
+    stdlib-only, and PyYAML is not installed in CI -- importing it turned a passing suite
+    into a collection error, which is a worse outcome than a slightly cruder parse.
+    """
+    text = WORKFLOW.read_text()
+    assert "build-push-action" in text, "no docker build step in the workflow"
+    m = re.search(r"^\s*build-args:\s*\|?\s*\n((?:\s+\S.*\n)+)", text, re.M)
+    return m.group(1) if m else ""
 
 
 def test_the_build_passes_the_commit():
     """THE fix. Without this the ARG defaults to 'unknown' and the whole chain is inert."""
-    args = _build_step()["with"].get("build-args", "")
+    args = _build_args_block()
     assert "GIT_SHA=" in args, "the build does not pass GIT_SHA; the image cannot identify itself"
     assert "github.sha" in args, "GIT_SHA must come from the commit, not a literal"
 

--- a/tests/test_purge.py
+++ b/tests/test_purge.py
@@ -72,7 +72,8 @@ def test_the_sweep_leaves_the_newest_dirs_alone(tmp_path):
     """A render that finished seconds ago may still be being fetched by the daemon, and the
     sweep has no coordination with in-flight jobs. Skipping the newest is cheaper than a
     race whose loser is a lost render."""
-    import os, time
+    import os
+    import time
     for i in range(8):
         d = tmp_path / f"job{i}"
         d.mkdir()

--- a/tests/test_worker_deploy.py
+++ b/tests/test_worker_deploy.py
@@ -14,7 +14,6 @@ import pathlib
 import shutil
 import stat
 import subprocess
-import textwrap
 
 DEPLOY = pathlib.Path(__file__).parent.parent / "deploy"
 RUN = DEPLOY / "run-worker.sh"


### PR DESCRIPTION
Part of #72's remaining acceptance criteria. Pairs with wanly-gpu-daemon#180 (reports it) and wanly-api#267 (stores and returns it).

## The gap

`start.sh` has printed this on every boot since the line was added:

```
image build: unknown
```

The `ARG GIT_SHA=unknown` existed; **the build never passed it.** So an image had no identity at all — which is half of why two workers running different code went unnoticed for 14 hours. Even reading the boot log told you nothing.

Verified on the live 3090 before changing anything:

```
$ docker exec wanly-ltx sh -c 'echo GIT_SHA=$GIT_SHA'
GIT_SHA=unknown
```

## What changed

- the workflow passes `--build-arg GIT_SHA=${{ github.sha }}`
- the Dockerfile exposes the same value as `WANLY_IMAGE_REF`, which the daemon reports in its heartbeat

Two names for one value, deliberately: `GIT_SHA` is what `start.sh` already prints and stays as it is, while the heartbeat field wants an unambiguous name inside an image that also clones ComfyUI and five node packs, each with a sha of its own.

The `unknown` default stays so a local `docker build` still works — an image that refuses to build outside CI would be worse than one that admits it doesn't know.

## Why it's a separate field from the daemon's commit

They drift independently. `docker restart` re-clones the daemon and reuses the image; the 3090 spent **37 hours** with a current daemon on a stale image. A single "version" string could not have expressed that, and that ambiguity is what made this morning's 422 look random.

## Tests

Four, and the one that matters — *the build passes the commit* — **fails when the `build-args` block is removed**, verified. Plus: the Dockerfile exposes the name the daemon actually reads (a rename on either side silently returns the field to null), the `unknown` default survives, and the boot-log line survives.

`pytest tests/` — **67 passed**.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J