### PR TITLE
deploy: the update timer stopped scheduling and said it was enabled

### DIFF
--- a/deploy/wanly-worker-update.timer
+++ b/deploy/wanly-worker-update.timer
@@ -3,14 +3,24 @@ Description=Check for a new wanly worker image periodically
 Documentation=https://github.com/DavidJBarnes/wanly-gpu-docker/issues/72
 
 [Timer]
-# Every 30 minutes. The check is a digest comparison after a `docker pull` of an image that is
-# almost always unchanged, so it costs a manifest fetch and nothing else -- there is no reason
-# to be shy about frequency. What SETS the pace is that it can only act while idle: a render
-# is 10-13 minutes, so a 30 minute cadence reliably finds a gap within the hour.
-OnBootSec=10min
-OnUnitActiveSec=30min
-# Do not have every box on the network pull at the same instant after a power cut.
+# Every 30 minutes, on an ABSOLUTE schedule.
+#
+# The first version used OnBootSec + OnUnitActiveSec and silently stopped scheduling.
+# OnUnitActiveSec only re-arms once the TIMER has triggered the service; with OnBootSec
+# already in the past there was nothing left to compute a next elapse from, so the timer sat
+# `active (elapsed)` with `Trigger: n/a` -- enabled, listed, and never going to fire again.
+# Installed and dead is the worst of both, because `is-enabled` says enabled.
+#
+# OnCalendar always has a next elapse regardless of boot time or when the service last ran,
+# which is what "check every 30 minutes, forever" actually needs.
+#
+# The cadence is not set by the cost of checking -- that is a manifest fetch on an image
+# that is almost always unchanged. It is set by having to wait for idle: a render is 10-13
+# minutes, so 30 minutes reliably finds a gap within the hour.
+OnCalendar=*:0/30
+# Do not have every box on the network pull at the same instant.
 RandomizedDelaySec=5min
+# Catch up after downtime rather than waiting for the next slot.
 Persistent=true
 
 [Install]

--- a/tests/test_worker_deploy.py
+++ b/tests/test_worker_deploy.py
@@ -192,3 +192,31 @@ def test_no_secret_is_committed():
     """worker.env carries the queue key and must never be in the repo."""
     assert not (DEPLOY / "worker.env").exists()
     assert (DEPLOY / "worker.env.example").read_text().count("QUEUE_API_KEY=\n") == 1
+
+
+class TestTheTimerActuallyFires:
+    """A timer that is enabled but has no next elapse is the worst failure here, because
+    `systemctl is-enabled` says "enabled" and `list-timers` lists it (wanly-gpu-docker#72).
+
+    The first version used OnBootSec + OnUnitActiveSec. OnUnitActiveSec only re-arms once the
+    TIMER has triggered the service; with OnBootSec already past there was nothing to compute
+    a next elapse from, so it sat `active (elapsed)` with `Trigger: n/a` -- installed, and
+    never going to run again. Observed on the 3090.
+    """
+
+    TIMER = DEPLOY / "wanly-worker-update.timer"
+
+    def test_it_uses_an_absolute_schedule(self):
+        s = self.TIMER.read_text()
+        assert "OnCalendar=" in s, (
+            "the timer needs an absolute schedule; OnBootSec/OnUnitActiveSec stops "
+            "re-arming and the timer silently never fires again"
+        )
+
+    def test_it_does_not_rely_on_onunitactivesec(self):
+        assert "OnUnitActiveSec=" not in self.TIMER.read_text()
+
+    def test_it_catches_up_after_downtime(self):
+        """A box that was off through a release should update on the next boot, not wait for
+        the following slot."""
+        assert "Persistent=true" in self.TIMER.read_text()


### PR DESCRIPTION
Fixes a defect in #73's timer, found while verifying #72 end to end.

## What was wrong

Installed on the 3090, the timer fired once and then never again:

```
Active: active (elapsed) since Sun 2026-09-06 07:46:03 MDT; 26min ago
Trigger: n/a
```

`OnUnitActiveSec` only re-arms once the **timer** has triggered the service. With `OnBootSec` already in the past there was nothing left to compute a next elapse from — so the timer sat `active (elapsed)` with no trigger, while `systemctl is-enabled` reported **enabled** and `list-timers` happily listed it.

It would have converged the worker exactly zero times.

That's the worst possible shape: the entire point of #72 is that a box stops silently drifting, and the mechanism meant to prevent it was itself silently not running. I'd have called it done on the strength of `is-enabled`.

## Fix

`OnCalendar=*:0/30` — always has a next elapse regardless of boot time or when the service last ran, which is what "every 30 minutes, forever" actually needs. `Persistent=true` so a box that was off through a release updates on its next boot rather than waiting for the following slot.

Cadence unchanged, and still set by having to wait for idle rather than by the cost of checking.

## Tests

Three, verified to fail against the old `OnBootSec`/`OnUnitActiveSec` form.

`pytest tests/` — **70 passed**.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J