### PR TITLE
Refuse the boot that cannot work, instead of downloading 58 GiB first (#77)

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -7,6 +7,17 @@
 #
 # On a fresh pod with no such mount there IS a fetch to do, and it is written below.
 #
+# WHICH OF THE TWO IT IS, IS DECIDED BY THE MOUNT, NOT BY GUESSWORK. A bind-mounted $MODELS is
+# host-provided and authoritative: a missing file there is a mount or host-tree fault and this
+# script says so and stops. An unmounted $MODELS is a pod's own directory and gets filled.
+#
+# That distinction is the whole of #77. A container started by hand with no -v and no --gpus
+# had an empty $MODELS, so every file legitimately looked missing, and it began downloading
+# 10Eros at 3 MB/s over the 3090's own complete copy of it -- onto a 30-40 GB overlay that
+# could never have held the 43 GB file. Nothing in the boot said any of that was wrong,
+# because on a pod it is the correct behaviour. It is now three refusals, each in one second:
+# no GPU (start.sh), an incomplete bind mount, and nowhere to put the bytes.
+#
 # WHAT a pod needs comes from the workflow, not from what happens to sit in the folder on the
 # 3090. That box holds 217 GB because it accumulated alternates -- three 43 GB checkpoints the
 # recipe never names. The workflow template names four files, and the recipe patches in two
@@ -85,16 +96,33 @@ fi
 #
 # HF_HOME still moves onto $MODELS. Whatever the mechanism, its cache must not land on the
 # container overlay, which is 30-40 GB against a 43 GB file.
+# Is a path a mount point in its own right? Parsed from /proc/self/mountinfo rather than by
+# calling `mountpoint`, which lives in util-linux and is not installed in this image. Field 5
+# of each mountinfo line is the mount point, compared whole so a path that merely appears
+# elsewhere on the line (the in-filesystem root, an option string) cannot match by accident.
+_is_mountpoint() {
+    local target="$1" mp
+    while read -r _ _ _ _ mp _; do
+        [ "$mp" = "$target" ] && return 0
+    done < /proc/self/mountinfo
+    return 1
+}
+
 export HF_HUB_DISABLE_XET=1
 export HF_HOME="$MODELS/.hf"
 mkdir -p "$HF_HOME" 2>/dev/null
 
-# dest_dir_under_$MODELS|final_filename|repo|path_in_repo (empty = filename at repo root)
+# dest_dir_under_$MODELS|final_filename|repo|path_in_repo|approx_GiB
+#
+# The size column is for the free-space precheck below and nothing else. It is approximate on
+# purpose: rounded up from the 3090's verified copies, so the check errs towards refusing a
+# marginal disk rather than towards starting a download that cannot finish. Integrity is not
+# its job -- the safetensors header check at the bottom of this file does that exactly.
 _WANTED=(
-  "ltx-2.3/diffusion_models|10Eros_v1.5_bf16.safetensors|TenStrip/LTX2.3-10Eros|"
-  "ltx-2.3/text_encoders|gemma_3_12B_it_fp8_scaled.safetensors|Comfy-Org/ltx-2|split_files/text_encoders/gemma_3_12B_it_fp8_scaled.safetensors"
-  "ltx-2.3/latent_upscale_models|ltx-2.3-spatial-upscaler-x2-1.1.safetensors|Lightricks/LTX-2.3|"
-  "loras|sulphur_distill_lora_condsafe.safetensors|SulphurAI/Sulphur-2-base|distill_loras/ltx-2.3-22b-distilled-lora-1.1_fro90_ceil72_condsafe.safetensors"
+  "ltx-2.3/diffusion_models|10Eros_v1.5_bf16.safetensors|TenStrip/LTX2.3-10Eros||43"
+  "ltx-2.3/text_encoders|gemma_3_12B_it_fp8_scaled.safetensors|Comfy-Org/ltx-2|split_files/text_encoders/gemma_3_12B_it_fp8_scaled.safetensors|13"
+  "ltx-2.3/latent_upscale_models|ltx-2.3-spatial-upscaler-x2-1.1.safetensors|Lightricks/LTX-2.3||1"
+  "loras|sulphur_distill_lora_condsafe.safetensors|SulphurAI/Sulphur-2-base|distill_loras/ltx-2.3-22b-distilled-lora-1.1_fro90_ceil72_condsafe.safetensors|1"
 )
 # Character LoRAs are NOT here: the daemon syncs those per claim from S3, so a pod carries
 # only the ones its jobs actually name.
@@ -186,23 +214,80 @@ PYEOF
 }
 
 NEED_FETCH=0
+MISSING_NAMES=""
+NEED_GIB=0
 for row in "${_WANTED[@]}"; do
-    IFS='|' read -r d n _r _p <<< "$row"
-    [ -s "$MODELS/$d/$n" ] || NEED_FETCH=1
+    IFS='|' read -r d n _r _p gib <<< "$row"
+    if [ ! -s "$MODELS/$d/$n" ]; then
+        NEED_FETCH=1
+        MISSING_NAMES="$MISSING_NAMES $d/$n"
+        NEED_GIB=$(( NEED_GIB + ${gib:-0} ))
+    fi
 done
 
 if [ "$NEED_FETCH" -eq 1 ]; then
+    echo "missing:$MISSING_NAMES"
+
+    # ---------- Is this model root the host's, or ours to fill? ----------
+    #
+    # A BIND-MOUNTED $MODELS is host-provided and AUTHORITATIVE. That is the 3090, where the
+    # tree is 217 GB of weights that exist outside any container and are managed by hand. If a
+    # file the recipe needs is not in it, the fault is in the mount or in the host tree, and
+    # the answer is to fix that -- not to fetch a second copy of a 43 GB file the box already
+    # has, and certainly not into a mount that is read-only anyway.
+    #
+    # An UNMOUNTED $MODELS is a pod's own directory, which starts empty and is ours to fill.
+    #
+    # Note this is only consulted when something is MISSING. A complete bind-mounted tree never
+    # reaches here, which is the 3090's normal boot: "models OK" in about a second.
+    if _is_mountpoint "$MODELS"; then
+        echo "!! FATAL: $MODELS is a bind mount from the host, and it is incomplete."
+        echo "!! The host provides these models; downloading a second copy here is wrong."
+        echo "!! Fix the host tree (on the 3090: /home/david/LTX-2/models) or the mount."
+        exit 1
+    fi
+
+    # Kept below the mount check, which now catches the 3090 with a better message. This
+    # remains for a read-only model root that is NOT a mount -- a baked-in or squashed image
+    # layer, say. Unreachable today; a one-line guard against a silent permission failure
+    # 40 GB into a download is worth keeping anyway.
     if [ ! -w "$MODELS" ]; then
-        echo "!! FATAL: models are missing and $MODELS is read-only."
-        echo "!! That is the 3090's bind mount — fix the mount rather than downloading here."
+        echo "!! FATAL: models are missing and $MODELS is read-only, so they cannot be staged."
+        exit 1
+    fi
+
+    # ---------- Somewhere to actually put it ----------
+    #
+    # The container overlay is 30-40 GB and 10Eros alone is 43. A fetch onto it cannot finish,
+    # however long it runs -- the first real pod died exactly this way, at 28 GB of 43, with
+    # its 60 GB volume sitting empty beside it, and a hand-started container on the 3090
+    # repeated it (#77). Both spent hours proving something knowable in one `df`.
+    #
+    # A little headroom on top, because the staging copy and the final file briefly coexist
+    # while the rename lands and hf's cache holds blocks of its own.
+    #
+    # No awk. `awk` here is mawk, which renders a large integer through CONVFMT "%.6g" -- so a
+    # 150 GB free-space figure prints as 1.5e+11 and bash cannot subtract it. That is the same
+    # trap that made a 28 GB download report itself as 1.9 GB. df's POSIX format is five fixed
+    # fields and bash can read them directly.
+    avail_bytes=0
+    read -r _ _ _ avail_bytes _ <<< "$(df -PB1 "$MODELS" 2>/dev/null | tail -1)"
+    avail_gib=$(( ${avail_bytes:-0} / 1073741824 ))
+    want_gib=$(( NEED_GIB + 5 ))
+    if [ "$avail_gib" -lt "$want_gib" ]; then
+        echo "!! FATAL: need ~${want_gib} GiB free under $MODELS to stage the missing models,"
+        echo "!! but only ${avail_gib} GiB is available."
+        echo "!! $MODELS is not a mount here, so this is the container's own filesystem —"
+        echo "!! it is almost certainly missing a volume (pod) or a -v bind mount (3090)."
+        echo "!! Refusing to start a download that cannot complete."
         exit 1
     fi
     python3 -c "import huggingface_hub" 2>/dev/null \
         || pip install --no-cache-dir -q huggingface_hub \
         || { echo "!! FATAL: huggingface_hub is not installed and could not be installed"; exit 1; }
-    echo "staging models (~58 GB on a cold pod; anything already present is skipped)"
+    echo "staging ~${NEED_GIB} GiB into $MODELS (${avail_gib} GiB free)"
     for row in "${_WANTED[@]}"; do
-        IFS='|' read -r d n r pth <<< "$row"
+        IFS='|' read -r d n r pth _gib <<< "$row"
         _fetch "$d" "$n" "$r" "$pth" || FAIL=1
     done
 fi

--- a/start.sh
+++ b/start.sh
@@ -38,7 +38,33 @@ exec > >(while IFS= read -r line; do
 echo "=== Wanly GPU Worker (LTX 2.3) ==="
 echo "image build: ${GIT_SHA:-unknown}"
 echo "(this log is also at /workspace/logs/daemon.log)"
-nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null || echo "WARNING: no GPU visible"
+# ---------- 0. A GPU, or nothing ----------
+# This used to print "WARNING: no GPU visible" and carry on, which is how a container started
+# by hand -- `docker run <image>` with no --gpus and no -v -- spent nine minutes downloading
+# 10Eros over the 3090's own complete copy of it (#77). Every later phase was going to fail;
+# the only question was how much bandwidth it burned first.
+#
+# There is no useful boot without a GPU. A worker that cannot render should not register,
+# should not claim, and should not stage 58 GB of weights it will never load.
+#
+# ALLOW_NO_GPU=1 exists for a debug shell into the image, and says so in the log so it can
+# never be mistaken for a healthy worker.
+if ! GPU_LINE=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null) \
+   || [ -z "$GPU_LINE" ]; then
+    if [ "${ALLOW_NO_GPU:-0}" = "1" ]; then
+        echo "WARNING: no GPU visible — continuing because ALLOW_NO_GPU=1."
+        echo "WARNING: this container CANNOT render. Do not expect it to claim work."
+    else
+        echo "!! FATAL: no GPU visible. nvidia-smi failed or reported nothing."
+        echo "!! On the 3090 this means the container was started without --gpus all;"
+        echo "!! use deploy/run-worker.sh rather than a hand-written docker run."
+        echo "!! On a pod it means the host is broken — kill it and take another."
+        echo "!! Set ALLOW_NO_GPU=1 only for a debug shell, never for a worker."
+        exit 1
+    fi
+else
+    echo "$GPU_LINE"
+fi
 
 # ---------- 0. sshd for direct TCP access (RunPod injects PUBLIC_KEY) ----------
 if [ -n "${PUBLIC_KEY:-}" ]; then

--- a/tests/test_boot_guards.py
+++ b/tests/test_boot_guards.py
@@ -1,0 +1,187 @@
+"""A worker that cannot possibly work must say so in one second (wanly-gpu-docker#77).
+
+A container started by hand -- `docker run <image>` with no `-v` and no `--gpus` -- began
+staging 10Eros from Hugging Face at 3 MB/s over the 3090's own complete copy of it, onto a
+30-40 GB overlay that could never have held the 43 GB file. Nothing in that boot log said
+anything was wrong, because on a pod the very same lines are correct behaviour.
+
+Three things were knowable at second zero and none of them stopped it: no GPU, no models
+mount, and nowhere to put 58 GiB. Each is now a refusal, and each is tested here by RUNNING
+the real code out of the real script rather than by restating it -- a restated copy passes
+while the shipped script regresses, which is the whole shape of this bug.
+"""
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+ROOT = pathlib.Path(__file__).parent.parent
+START_SH = ROOT / "start.sh"
+DOWNLOAD_SH = ROOT / "download_models.sh"
+
+
+def _extract(path, start_pat, end_pat):
+    """Pull a block out of a shell script so the test runs the shipped lines themselves."""
+    text = path.read_text()
+    m = re.search(f"{start_pat}.*?{end_pat}", text, re.S | re.M)
+    assert m, f"could not find {start_pat!r}..{end_pat!r} in {path.name} -- did it move?"
+    return m.group(0)
+
+
+def _run(script, env=None, cwd=None):
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True, text=True, timeout=60,
+        env={**os.environ, **(env or {})}, cwd=cwd,
+    )
+
+
+# --------------------------------------------------------------------------- no GPU
+
+GPU_BLOCK = _extract(START_SH, r"^if ! GPU_LINE=", r"^fi$")
+
+
+def _fake_nvidia_smi(tmp_path, *, exit_code, stdout=""):
+    d = tmp_path / "bin"
+    d.mkdir(exist_ok=True)
+    f = d / "nvidia-smi"
+    f.write_text(f'#!/bin/bash\nprintf "%s" {stdout!r}\nexit {exit_code}\n')
+    f.chmod(0o755)
+    return str(d)
+
+
+def test_no_gpu_aborts_the_boot(tmp_path):
+    """nvidia-smi failing used to print WARNING and carry straight on into a 58 GiB fetch."""
+    bindir = _fake_nvidia_smi(tmp_path, exit_code=1)
+    r = _run(GPU_BLOCK, env={"PATH": f"{bindir}:{os.environ['PATH']}", "ALLOW_NO_GPU": "0"})
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "FATAL: no GPU visible" in r.stdout
+    # The message has to name the actual mistake, or it sends you looking at the GPU.
+    assert "--gpus all" in r.stdout
+
+
+def test_a_silent_nvidia_smi_also_aborts(tmp_path):
+    """Exit 0 with no output is not a GPU. Only the non-empty line counts."""
+    bindir = _fake_nvidia_smi(tmp_path, exit_code=0, stdout="")
+    r = _run(GPU_BLOCK, env={"PATH": f"{bindir}:{os.environ['PATH']}", "ALLOW_NO_GPU": "0"})
+    assert r.returncode == 1, r.stdout + r.stderr
+
+
+def test_a_real_gpu_passes_and_is_printed(tmp_path):
+    bindir = _fake_nvidia_smi(tmp_path, exit_code=0, stdout="NVIDIA GeForce RTX 3090, 24576 MiB")
+    r = _run(GPU_BLOCK, env={"PATH": f"{bindir}:{os.environ['PATH']}"})
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "RTX 3090" in r.stdout
+
+
+def test_allow_no_gpu_continues_but_says_it_cannot_render(tmp_path):
+    """The debug escape hatch must never leave a log that reads like a healthy worker."""
+    bindir = _fake_nvidia_smi(tmp_path, exit_code=1)
+    r = _run(GPU_BLOCK, env={"PATH": f"{bindir}:{os.environ['PATH']}", "ALLOW_NO_GPU": "1"})
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "CANNOT render" in r.stdout
+
+
+# ------------------------------------------------------------------- mountpoint parsing
+
+MOUNTPOINT_FN = _extract(DOWNLOAD_SH, r"^_is_mountpoint\(\) \{", r"^\}$")
+
+
+def _real_mountpoints():
+    out = set()
+    for line in pathlib.Path("/proc/self/mountinfo").read_text().splitlines():
+        fields = line.split()
+        if len(fields) >= 5:
+            out.add(fields[4])
+    return out
+
+
+@pytest.mark.parametrize("path", ["/", "/proc"])
+def test_known_mountpoints_are_recognised(path):
+    if path not in _real_mountpoints():
+        pytest.skip(f"{path} is not a mountpoint on this host")
+    r = _run(f"{MOUNTPOINT_FN}\n_is_mountpoint {path!r}")
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_an_ordinary_directory_is_not_a_mountpoint(tmp_path):
+    d = tmp_path / "models"
+    d.mkdir()
+    r = _run(f"{MOUNTPOINT_FN}\n_is_mountpoint {str(d)!r}")
+    assert r.returncode == 1, r.stdout + r.stderr
+
+
+def test_a_path_appearing_elsewhere_on_the_line_does_not_match():
+    """Field 5 only. `grep " $path "` would match the in-filesystem root or an option string."""
+    fake = "36 35 98:0 /workspace/models /somewhere/else rw,noatime - ext4 /dev/root rw\n"
+    script = f"""
+{MOUNTPOINT_FN.replace('< /proc/self/mountinfo', '< "$FAKE_MOUNTINFO"')}
+_is_mountpoint /workspace/models
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".mountinfo", delete=False) as fh:
+        fh.write(fake)
+        name = fh.name
+    try:
+        r = _run(script, env={"FAKE_MOUNTINFO": name})
+        assert r.returncode == 1, "matched a path that is not the mount point"
+    finally:
+        os.unlink(name)
+
+
+# ------------------------------------------------ an incomplete bind mount never downloads
+
+
+def test_incomplete_bind_mount_refuses_instead_of_fetching():
+    """End to end, against a real mountpoint: /proc is mounted and holds no models.
+
+    The assertion that matters is the absence of "fetching" -- exiting non-zero would also be
+    satisfied by failing *after* starting a download, which is exactly what #77 did.
+    """
+    if "/proc" not in _real_mountpoints():
+        pytest.skip("no /proc mountpoint")
+    r = subprocess.run(
+        ["bash", str(DOWNLOAD_SH)],
+        capture_output=True, text=True, timeout=60,
+        env={**os.environ, "MODELS_DIR": "/proc"},
+    )
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "is a bind mount from the host" in r.stdout
+    assert "fetching" not in r.stdout, "started a download from a bind-mounted model root"
+
+
+# --------------------------------------------------------------------- free-space parsing
+
+DF_LINES = _extract(DOWNLOAD_SH, r"^    avail_bytes=0$", r"^    avail_gib=.*?$")
+
+
+def test_free_space_is_read_as_a_plain_integer(tmp_path):
+    """mawk renders a large integer as 1.5e+11 through CONVFMT, which bash cannot subtract.
+
+    That trap already cost this file three bugs, so the free-space read uses no awk at all.
+    This asserts the value both parses as an integer and equals what df reports.
+    """
+    script = f'MODELS={str(tmp_path)!r}\n{DF_LINES}\necho "$avail_gib"'
+    r = _run(script)
+    assert r.returncode == 0, r.stdout + r.stderr
+    got = r.stdout.strip()
+    assert re.fullmatch(r"\d+", got), f"not a plain integer: {got!r}"
+    expected = shutil.disk_usage(tmp_path).free // (1024 ** 3)
+    assert abs(int(got) - expected) <= 1, f"{got} vs df/statvfs {expected}"
+
+
+# ------------------------------------------------------------------------ the wanted rows
+
+
+def test_every_wanted_row_declares_a_size():
+    """A row missing its size column contributes 0 GiB and silently weakens the precheck."""
+    block = _extract(DOWNLOAD_SH, r"^_WANTED=\(", r"^\)$")
+    rows = re.findall(r'^\s*"(.+)"\s*$', block, re.M)
+    assert len(rows) >= 4, f"expected the four staged models, found {len(rows)}"
+    for row in rows:
+        fields = row.split("|")
+        assert len(fields) == 5, f"{row!r} has {len(fields)} fields, want 5"
+        assert fields[4].isdigit() and int(fields[4]) > 0, f"{row!r} has no usable size"


### PR DESCRIPTION
Closes #77.

A container started by hand on the 3090 — `docker run <image>` with no `-v` and no `--gpus` —
spent nine minutes staging 10Eros at 3 MB/s over the box's own complete copy of it, onto a
30–40 GB overlay that could never have held the 43 GB file.

**The defect is that nothing in the boot log said anything was wrong.** On a pod those exact
lines are correct: an empty `$MODELS` means the files really are missing and fetching really is
the answer. Three things were knowable at second zero and none of them stopped it.

## Three refusals

| guard | where | catches |
|---|---|---|
| no GPU is fatal | `start.sh` | the hand-started container, in one second, before Phase 1 |
| a bind-mounted `$MODELS` is authoritative | `download_models.sh` | a mount that is present but incomplete |
| free space checked before the first byte | `download_models.sh` | a fetch that cannot finish |

**`start.sh`** printed `WARNING: no GPU visible` and carried straight on. A worker with no GPU
cannot render, so it should not register, claim, or stage weights it will never load.
`ALLOW_NO_GPU=1` keeps a debug shell possible and prints that the container cannot render, so
the log can never be mistaken for a healthy worker.

**Whether to fetch is now decided by the mount** rather than inferred from an empty directory.
A bind-mounted `$MODELS` is the host's 217 GB tree: a missing file there is a mount or host-tree
fault, and the fix is that, not a second copy of a 43 GB file — into a mount that is read-only
anyway. An unmounted `$MODELS` is a pod's own directory and gets filled exactly as before. Read
from `/proc/self/mountinfo` with field 5 compared whole; `mountpoint` is util-linux and is not
in this image.

**Free space** is checked against the sum of what is actually missing. `_WANTED` carries an
approximate size per row so the figure is derived rather than a stale comment, and the staging
banner states the real number. The first real pod died at 28 GB of 43 with its 60 GB volume
sitting empty beside it; this repeated it. Both spent hours proving what one `df` answers.

The `df` read uses **no awk**: mawk renders a large integer through `CONVFMT "%.6g"`, so 150 GB
free prints as `1.5e+11` and bash cannot subtract it — the same trap that made a 28 GB download
report itself as 1.9 GB.

## Pods are unaffected

A pod gets a 150 GB volume at `/workspace` (`runpod_volume_mount_path`), so `/workspace/models`
is a plain directory inside it — not a mountpoint — and staging proceeds as before, with 150 GB
against the ~63 GiB required. The same guard correctly rejects the 40 GB container disk, which
is the case that has always failed, only slowly.

## Verified

Recreated on the 3090 through `deploy/run-worker.sh`:

```
14:54:11 NVIDIA GeForce RTX 3090, 24576 MiB
14:54:11 PHASE 1/6: models
14:54:11   diffusion_models: 4 file(s) — 10Eros_v1.5_bf16.safetensors ...
14:54:12   32 file(s) OK
14:54:12 models OK
```

One second, no fetch, 32 safetensors header-verified. The host tree was complete the whole time,
including `loras/sulphur_distill_lora_condsafe.safetensors`.

## Tests

`tests/test_boot_guards.py` runs the shipped lines rather than restating them — a restated copy
passes while the real script regresses, which is the shape of this bug:

- the GPU block and `_is_mountpoint` are **extracted from the scripts** and executed, against a
  stubbed `nvidia-smi` (fails / silent-succeeds / reports a 3090) and against real mountpoints;
- the bind-mount refusal runs `download_models.sh` **end to end** against `/proc` — a real
  mountpoint holding no models — and asserts no download started, not merely that it exited
  non-zero (exiting after starting a download is exactly what #77 did);
- the free-space read is compared to `statvfs`, so a regression back to awk fails here;
- `_WANTED` is checked to declare a usable size on every row, since a missing one silently
  contributes 0 GiB.

81 passed.

## Follow-up, not in this PR

The `#76` update timer was never installed on the 3090 — `wanly-worker-update.timer` could not
be found. Installing it is what stops `docker pull` by hand from being the workflow at all; I'll
do that on the box once this merges.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J