### PR TITLE
Name the worker container wanly-gpu-docker

### DIFF
--- a/deploy/run-worker.sh
+++ b/deploy/run-worker.sh
@@ -24,7 +24,7 @@ ENV_FILE="${WORKER_ENV:-$HERE/worker.env}"
 set -a; . "$ENV_FILE"; set +a
 
 IMAGE="${IMAGE:-davidjbarnes/wanly-gpu-docker:latest}"
-NAME="${NAME:-wanly-ltx}"
+NAME="${NAME:-wanly-gpu-docker}"
 
 : "${QUEUE_API_KEY:?set QUEUE_API_KEY in $ENV_FILE}"
 : "${FRIENDLY_NAME:?set FRIENDLY_NAME in $ENV_FILE}"

--- a/deploy/update-worker.sh
+++ b/deploy/update-worker.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE="${IMAGE:-davidjbarnes/wanly-gpu-docker:latest}"
-NAME="${NAME:-wanly-ltx}"
+NAME="${NAME:-wanly-gpu-docker}"
 
 # Needed for the idle check below: QUEUE_URL, QUEUE_API_KEY and FRIENDLY_NAME identify this
 # worker to the API. Sourced rather than required, so the script still runs (and still
@@ -29,6 +29,19 @@ if [ -f "$ENV_FILE" ]; then
 fi
 
 log() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $*"; }
+
+# The container was called wanly-ltx before #77 renamed it. ADOPT it rather than walking past
+# it into run-worker.sh, which would leave two containers with the same FRIENDLY_NAME claiming
+# from the same queue -- the API identifies a worker by that name and cannot tell them apart,
+# so they would fight over segments and each would look like the other going wrong.
+#
+# A rename keeps the running container exactly as it is, so this costs nothing and is a no-op
+# once done. Harmless to leave in place.
+LEGACY_NAME="wanly-ltx"
+if ! docker inspect "$NAME" >/dev/null 2>&1 && docker inspect "$LEGACY_NAME" >/dev/null 2>&1; then
+    log "adopting the pre-#77 container $LEGACY_NAME as $NAME"
+    docker rename "$LEGACY_NAME" "$NAME"
+fi
 
 if ! docker inspect "$NAME" >/dev/null 2>&1; then
     log "no container named $NAME — creating it"

--- a/tests/test_worker_deploy.py
+++ b/tests/test_worker_deploy.py
@@ -11,6 +11,7 @@ leaves a segment to be reclaimed; never recreating leaves the drift in place.
 """
 import os
 import pathlib
+import re
 import shutil
 import stat
 import subprocess
@@ -58,6 +59,22 @@ class TestTheContainerSpecIsComplete:
         assert 'QUEUE_API_KEY:?' in RUN.read_text()
 
 
+class TestTheRename:
+    def test_the_legacy_container_is_adopted_not_duplicated(self):
+        """#77 renamed the container. Creating a second one beside the old is the bad outcome.
+
+        Two containers with the same FRIENDLY_NAME both claim from the same queue, and the API
+        identifies a worker by that name -- it cannot tell them apart, so they fight over
+        segments and each looks like the other going wrong.
+        """
+        s = UPDATE.read_text()
+        assert "docker rename" in s, "no adoption path for the pre-rename container"
+        rename_at = s.index("docker rename")
+        create_at = s.index('exec "$HERE/run-worker.sh"')
+        assert rename_at < create_at, \
+            "the rename must be attempted before falling through to creating a new container"
+
+
 class TestTheIdleCheck:
     def test_it_asks_inside_the_container(self):
         """The engine binds 127.0.0.1 INSIDE the container, so the -p 8190:8190 mapping
@@ -67,6 +84,9 @@ class TestTheIdleCheck:
         s = UPDATE.read_text()
         assert 'docker exec "$NAME" curl' in s, \
             "the idle check must run inside the container, not against the published port"
+
+
+DEFAULT_NAME = re.search(r'^NAME="\$\{NAME:-([^}]+)\}"', UPDATE.read_text(), re.M).group(1)
 
 
 def _stage(tmp, *, running_image, latest_image, engine_busy, worker_status):
@@ -87,7 +107,9 @@ def _stage(tmp, *, running_image, latest_image, engine_busy, worker_status):
     docker = "\n".join([
         "#!/usr/bin/env bash",
         'case "$*" in',
-        '  "inspect -f {{.Image}} wanly-ltx")  echo "%s"; exit 0 ;;' % running_image,
+        # Read from the script rather than hardcoded, so renaming the container does not
+        # silently turn this stub into a no-op that answers every inspect with exit 0.
+        '  "inspect -f {{.Image}} %s")  echo "%s"; exit 0 ;;' % (DEFAULT_NAME, running_image),
         '  "pull -q "*)                        exit 0 ;;',
         '  "image inspect "*)                  echo "%s"; exit 0 ;;' % latest_image,
         '  *"curl"*)                           %s ;;' % engine_case,


### PR DESCRIPTION
The long-lived container's default name becomes `wanly-gpu-docker`, matching the image and the
repo. It was `wanly-ltx`, which is why the container started by hand and the one
`deploy/run-worker.sh` creates were two different things on the 3090 rather than one.

`update-worker.sh` **adopts** the old container instead of walking past it. Without that, the
first timer tick would find no `wanly-gpu-docker`, fall through to `run-worker.sh`, and leave
two containers with the same `FRIENDLY_NAME` claiming from the same queue — the API identifies
a worker by that name and cannot tell them apart, so they would fight over segments and each
would look like the other going wrong. A `docker rename` keeps the running container exactly as
it is, and is a no-op once done.

The deploy test no longer hardcodes the name: it reads the default out of `update-worker.sh`.
The `docker` stub matches on the exact `inspect -f {{.Image}} <name>` string, so a rename would
otherwise have turned the stub into a no-op answering every call with exit 0 — the tests would
have kept passing while testing nothing.

82 passed.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J