### PR TITLE
Recipe path chains a second character LoRA

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -768,15 +768,16 @@ def run_job(job: Job):
             # on a single LoadImage which drives size as well.
             graph = comfy.load_workflow(resolve_workflow(recipe_mod.RECIPE_WORKFLOW))
             w, h = derive_size(workdir / "kf1.png")
-            lora = job.req.loras[0] if job.req.loras else None
+            # Every entry of `loras` is a CHARACTER on this path (content LoRAs travel in
+            # their own field), one per person in the shot, in slot order (console#473).
+            # The cap is checked at submit, where a 422 reaches the caller.
             graph = recipe_mod.resolve(
                 graph, guides[0]["name"], w, h,
                 prompt=job.req.prompt,
                 negative=job.req.negative_prompt,
                 checkpoint=job.req.checkpoint,
-                char_lora=(lora.name if lora else None),
-                char_s1=(lora.at(1) if lora else 0.8),
-                char_s2=(lora.at(2) if lora else 1.5),
+                char_loras=[{"name": lo.name, "s1": lo.at(1), "s2": lo.at(2)}
+                            for lo in job.req.loras],
                 # Checked here, before anything is submitted. A LoRA that is merely absent
                 # should cost a 422 in the first second, not a failure deep in a render that
                 # has already held the GPU — and the message names the file and lists what IS
@@ -801,10 +802,11 @@ def run_job(job: Job):
                            else random.randint(0, 2**31 - 1))
             job.req.width, job.req.height = w, h
             gh = recipe_mod.graph_hash(graph)
-            # Name the output for what it IS: <char lora>-<recipe slug>.
-            char = re.sub(r"\.safetensors$", "", (lora.name if lora else "") or "")
-            if char.lower() in ("", "none"):
-                char = "no-char-lora"
+            # Name the output for what it IS: <char lora(s)>-<recipe slug>. Two people join
+            # with "+", so the filename says who is in the shot.
+            stems = [re.sub(r"\.safetensors$", "", lo.name) for lo in job.req.loras]
+            stems = [st for st in stems if st.lower() not in ("", "none")]
+            char = "+".join(stems) or "no-char-lora"
             slug = re.sub(r"[^a-z0-9]+", "-", job.req.recipe.lower()).strip("-")
             graph["140"]["inputs"]["filename_prefix"] = f"{char}-{slug}"
             # No "as validated" claim any more. That compared this graph against the sheet's
@@ -959,6 +961,13 @@ def submit(req: JobRequest):
                 f"{name}={v} must be divisible by 64. The two-stage distilled "
                 f"graph (spatial upsampler) requires it; only one-stage "
                 f"graphs accept 32. Nearest: {(v // 64) * 64} or {(v // 64 + 1) * 64}.")
+    # On the recipe path every `loras` entry is a person, and the graph has room for two
+    # (console#473). Refused here, in the first second, rather than as a failed job after
+    # the claim -- and named, so the caller knows it is the count and not a missing file.
+    if req.recipe and len(req.loras) > len(recipe_mod.CHAR_NODE_IDS):
+        raise HTTPException(422,
+            f"{len(req.loras)} character LoRAs; a recipe render takes at most "
+            f"{len(recipe_mod.CHAR_NODE_IDS)}")
     placement = plan(req)
     job = Job(id=uuid.uuid4().hex[:12], req=req, placement=placement)
     with _LOCK:

--- a/engine/recipe.py
+++ b/engine/recipe.py
@@ -64,15 +64,28 @@ def _is_none(name: str | None) -> bool:
     return n in ("", "none")
 
 
+#: Node-id prefixes for the character LoRA pairs, one per slot: slot 0 is 9621/9622 (so
+#: every existing single-character graph hashes exactly as it did), slot 1 is 9631/9632.
+#: Content ids run 9601..9608 and stop well short of either. A third person is one more
+#: entry here -- and a second `<TRIGGER>` slot everywhere upstream (console#473).
+CHAR_NODE_IDS = ("962", "963")
+
+
 def resolve(graph: dict, image_name: str, width: int, height: int, *,
             prompt: str, negative: str | None = None, checkpoint: str | None = None,
             char_lora: str | None = None, char_s1: float = 0.8, char_s2: float = 1.5,
+            char_loras: list | None = None,
             content_loras: list | None = None,
             img_compression: int | None = None) -> dict:
     """Patch the validated graph with this render's configuration.
 
     Values only, never topology — the graph template is the validated recipe and this moves
     the handful of fields that vary between renders.
+
+    `char_loras` is the list form -- `[{name, s1, s2}, ...]`, up to `len(CHAR_NODE_IDS)`,
+    in slot order -- for a shot with two people in it (console#473). `char_lora/char_s1/
+    char_s2` remain as the one-character shorthand every existing caller uses, and produce
+    the identical graph: a single character is `char_loras=[that one]`.
     """
     g = json.loads(json.dumps(graph))
     ck = checkpoint or DEFAULT_CHECKPOINT
@@ -123,19 +136,33 @@ def resolve(graph: dict, image_name: str, width: int, height: int, *,
     # building the chain, or it would sit in front of everything below.
     if "9601" in g:
         del g["9601"]
-    s1 = float(char_s1)
-    s2 = float(char_s2)
     # A character LoRA is optional. "none" renders the recipe on the checkpoint
     # alone -- useful for judging what the LoRA is actually contributing, and
-    # for a shot where the start frame already carries the identity.
-    char_name = (char_lora or "").strip()
-    want_char = not _is_none(char_name)
+    # for a shot where the start frame already carries the identity. In the list form a
+    # "none" in either slot is skipped the same way, so a two-person pose can still be
+    # rendered with one identity to see what the other was contributing.
+    if char_loras is None:
+        char_loras = [{"name": char_lora, "s1": char_s1, "s2": char_s2}]
+    chars = []
+    for entry in char_loras:
+        name = str(entry.get("name") or "").strip()
+        if _is_none(name):
+            continue
+        chars.append({
+            "name": name if name.endswith(".safetensors") else name + ".safetensors",
+            "s1": float(entry["s1"]) if entry.get("s1") is not None else 0.8,
+            "s2": float(entry["s2"]) if entry.get("s2") is not None else 1.5,
+        })
+    if len(chars) > len(CHAR_NODE_IDS):
+        raise ValueError(
+            f"{len(chars)} character LoRAs; the recipe graph has room for "
+            f"{len(CHAR_NODE_IDS)} (console#473)")
     # Per stage, like the character strengths beside them. This was 0.6 hardcoded for BOTH
     # stages, which is a configuration rather than a default -- stage 1 generates at half
     # size from noise and stage 2 refines the 2x-upscaled latent, so one number for both is
     # a different setup, not a simpler one. 0.6/0.6 remains the default so a caller that
     # says nothing gets exactly the graph that was validated.
-    for tag, (branch, strength) in {"1": ("337", s1), "2": ("372", s2)}.items():
+    for tag, branch in {"1": "337", "2": "372"}.items():
         prev = ["301", 0]
         # Node ids: 9601/9602 for the first content LoRA (unchanged, so a single-LoRA pose
         # produces the same graph it always did), then 9603/9604, 9605/9606... Stops well
@@ -157,12 +184,17 @@ def resolve(graph: dict, image_name: str, width: int, height: int, *,
                       "_meta": {"title": f"content {i + 1} stage {tag}" if len(contents) > 1
                                 else f"content stage {tag}"}}
             prev = [cid, 0]
-        if want_char:
-            kid = f"962{tag}"
-            char = char_name if char_name.endswith(".safetensors") else char_name + ".safetensors"
+        # Character LoRAs LAST, closest to the sampler, one pair per person. Slot 0 keeps
+        # its id and its unnumbered title so a one-person graph hashes as it always has --
+        # the hash is the regression trail. Slot 1 is `char 2`, and reads off slot 0.
+        for i, c in enumerate(chars):
+            kid = f"{CHAR_NODE_IDS[i]}{tag}"
             g[kid] = {"class_type": "LoraLoaderModelOnly",
-                      "inputs": {"lora_name": char, "strength_model": strength, "model": prev},
-                      "_meta": {"title": f"char stage {tag}"}}
+                      "inputs": {"lora_name": c["name"],
+                                 "strength_model": c["s1"] if tag == "1" else c["s2"],
+                                 "model": prev},
+                      "_meta": {"title": f"char stage {tag}" if i == 0
+                                else f"char {i + 1} stage {tag}"}}
             prev = [kid, 0]
         g[branch]["inputs"]["model"] = prev
     return g
@@ -229,6 +261,10 @@ def lora_stack_note(graph: dict) -> str:
     # Every content LoRA, in the order applied — the order is part of the configuration and
     # a result cannot be tied to a chain that is only half reported.
     parts = [pair("9621", "9622", "char")]
+    # A second person, only when there is one -- the common line must not grow a
+    # "char2 none" nobody asked about.
+    if "9631" in graph or "9632" in graph:
+        parts.append(pair("9631", "9632", "char2"))
     found = []
     for i in range(4):
         n1, n2 = f"96{1 + i * 2:02d}", f"96{2 + i * 2:02d}"

--- a/tests/test_recipe_resolve.py
+++ b/tests/test_recipe_resolve.py
@@ -360,3 +360,81 @@ def test_every_line_that_names_the_base_model_reads_it_from_the_graph():
     for ln in naming:
         assert "base_model_note(graph)" in ln, (
             f"this line derives the base model some other way: {ln}")
+
+
+# ---------------------------------------------------------------- two people (console#473)
+
+TWO = [{"name": "pay_v2_e05", "s1": 0.8, "s2": 1.5},
+       {"name": "david_v1_final", "s1": 0.7, "s2": 1.2}]
+
+
+def test_a_second_character_chains_after_the_first_on_both_stages(graph):
+    g = recipe_mod.resolve(graph, **BASE, char_loras=TWO)
+    assert g["9621"]["inputs"]["lora_name"] == "pay_v2_e05.safetensors"
+    assert g["9631"]["inputs"]["lora_name"] == "david_v1_final.safetensors"
+    assert g["9631"]["inputs"]["model"] == ["9621", 0]
+    assert g["337"]["inputs"]["model"] == ["9631", 0]
+    assert g["9632"]["inputs"]["model"] == ["9622", 0]
+    assert g["372"]["inputs"]["model"] == ["9632", 0]
+    assert g["9631"]["inputs"]["strength_model"] == 0.7
+    assert g["9632"]["inputs"]["strength_model"] == 1.2
+    assert g["9631"]["_meta"]["title"] == "char 2 stage 1"
+
+
+def test_a_single_character_graph_is_unchanged_by_the_list_form(graph):
+    """The hash is the regression trail; the list form of one character must not move it."""
+    scalar = recipe_mod.resolve(graph, **BASE, char_lora="pay_v2_e05", char_s1=0.8, char_s2=1.5)
+    listed = recipe_mod.resolve(graph, **BASE, char_loras=[TWO[0]])
+    assert recipe_mod.graph_hash(scalar) == recipe_mod.graph_hash(listed)
+    assert "9631" not in listed and "9632" not in listed
+
+
+def test_the_second_character_never_collides_with_content_ids(graph):
+    contents = [{"name": f"c{i}", "s1": 0.6, "s2": 0.6} for i in range(4)]
+    g = recipe_mod.resolve(graph, **BASE, char_loras=TWO, content_loras=contents)
+    ids = {"9601", "9602", "9603", "9604", "9605", "9606", "9607", "9608",
+           "9621", "9622", "9631", "9632"}
+    assert ids <= set(g)
+    # content 4 -> char 1 -> char 2 -> branch, on stage 1
+    assert g["9621"]["inputs"]["model"] == ["9607", 0]
+    assert g["9631"]["inputs"]["model"] == ["9621", 0]
+    assert g["337"]["inputs"]["model"] == ["9631", 0]
+
+
+def test_the_note_names_both_characters(graph):
+    g = recipe_mod.resolve(graph, **BASE, char_loras=TWO)
+    note = recipe_mod.lora_stack_note(g)
+    assert "char pay_v2_e05.safetensors @0.8/1.5" in note
+    assert "char2 david_v1_final.safetensors @0.7/1.2" in note
+
+
+def test_one_person_notes_do_not_grow_a_char2(graph):
+    g = recipe_mod.resolve(graph, **BASE, char_loras=[TWO[0]])
+    assert "char2" not in recipe_mod.lora_stack_note(g)
+
+
+@pytest.mark.parametrize("spelling", ["none", "None", "", "none.safetensors"])
+def test_a_none_in_the_second_slot_is_skipped(graph, spelling):
+    g = recipe_mod.resolve(graph, **BASE, char_loras=[TWO[0], {"name": spelling}])
+    assert "9631" not in g
+    assert g["337"]["inputs"]["model"] == ["9621", 0]
+
+
+def test_a_none_in_the_first_slot_still_places_the_second_at_its_own_id(graph):
+    """Slot ids are positional after filtering: the one remaining person takes slot 0, so
+    its graph is the ordinary one-person graph rather than a lone 9631."""
+    g = recipe_mod.resolve(graph, **BASE, char_loras=[{"name": "none"}, TWO[1]])
+    assert g["9621"]["inputs"]["lora_name"] == "david_v1_final.safetensors"
+    assert "9631" not in g
+
+
+def test_more_than_two_characters_is_refused(graph):
+    with pytest.raises(ValueError, match="room for 2"):
+        recipe_mod.resolve(graph, **BASE, char_loras=TWO + [{"name": "third"}])
+
+
+def test_the_id_table_is_the_only_cap():
+    import inspect
+    src = inspect.getsource(recipe_mod.resolve)
+    assert "len(CHAR_NODE_IDS)" in src
+    assert recipe_mod.CHAR_NODE_IDS == ("962", "963")


### PR DESCRIPTION
PR 1 of 4 for DavidJBarnes/wanly-console#473 (two character LoRAs in one render). Deploys first: the engine must accept two characters before the daemon, API and console emit them.

- `resolve()` takes `char_loras=[{name, s1, s2}, …]` in slot order and injects one `LoraLoaderModelOnly` pair per person after the content chain. Slot 0 keeps 9621/9622 and its title, so every existing one-person graph hashes identically (asserted). Slot 1 is 9631/9632, titled `char 2`. The scalar `char_lora/char_s1/char_s2` stay as the one-person shorthand.
- `lora_stack_note` reports `char2 …` only when present, so one-person log lines are unchanged.
- `app.py`: every `loras` entry on the recipe path is a person; the output filename joins the stems with `+`; more than two is a 422 at submit, named.
- "none" in either slot is skipped as before; slots are positional after filtering.

`pytest tests/`: 106 passed (10 new). Code-only change in the `COPY engine/` layer, compiled and import-checked; no dependency pins touched.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW