### PR TITLE
The trainer refuses to publish a checkpoint with no safetensors header

### DIFF
--- a/tests/test_checkpoint_readable.py
+++ b/tests/test_checkpoint_readable.py
@@ -1,0 +1,41 @@
+"""A zero-filled checkpoint is never published (2026-09-08).
+
+The host hard-reset seconds after the trainer wrote the final ComfyUI-format checkpoint;
+ext4 kept the size and zeroed the contents. The "interrupted run" path uploaded it, and every
+render with that character then failed inside ComfyUI with a JSON error that named nothing.
+"""
+import json
+import struct
+from pathlib import Path
+
+from wanly_worker.services.lora_trainer.poller import Poller
+
+
+def _good(p: Path) -> None:
+    header = json.dumps({"__metadata__": {}, "w": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}}).encode()
+    p.write_bytes(struct.pack("<Q", len(header)) + header + b"\0" * 4)
+
+
+def test_a_real_safetensors_header_passes(tmp_path):
+    f = tmp_path / "x.comfy.safetensors"; _good(f)
+    assert Poller._readable(f)
+
+
+def test_a_zero_filled_file_is_refused(tmp_path):
+    f = tmp_path / "Me_v2.comfy.safetensors"; f.write_bytes(b"\0" * 4096)
+    assert not Poller._readable(f)
+
+
+def test_a_truncated_header_is_refused(tmp_path):
+    f = tmp_path / "x.comfy.safetensors"; f.write_bytes(struct.pack("<Q", 500) + b"{\"a\":")
+    assert not Poller._readable(f)
+
+
+def test_the_sweep_refuses_it_and_records_the_failure():
+    import inspect
+    src = inspect.getsource(Poller._sweep_checkpoints)
+    assert "if not self._readable(path):" in src
+    assert "failed.append(str(path))" in src
+    # Ordered: only a SETTLED file is judged, so a checkpoint still being written is not
+    # mistaken for a corrupt one.
+    assert src.index("if self._settled(path):") < src.index("self._readable(path)")

--- a/tests/test_image_description.py
+++ b/tests/test_image_description.py
@@ -111,12 +111,15 @@ def test_the_default_model_matches_wanly_apis_default():
     cfg = pathlib.Path(__file__).resolve().parents[2] / "wanly-api" / "app" / "config.py"
     if not cfg.exists():
         pytest.skip("wanly-api is not checked out beside this repo")
-    for line in cfg.read_text().splitlines():
-        if line.strip().startswith(("image_description_model:", "joycaption_model:")):
-            want = line.split("=", 1)[1].strip().strip('"').strip("'")
-            assert jc.MODEL == want, f"this image defaults to {jc.MODEL}, wanly-api asks for {want}"
-            return
-    pytest.fail("image_description_model/joycaption_model not found in wanly-api/app/config.py")
+    import re
+    # `image_description_model: str = Field("joycaption:beta-one", validation_alias=...)` --
+    # the first quoted string after the field name, whichever line it lands on.
+    m = re.search(r"(?:image_description_model|joycaption_model)\s*:\s*str\s*=\s*(?:Field\(\s*)?[\"']([^\"']+)[\"']",
+                  cfg.read_text())
+    if not m:
+        pytest.fail("image_description_model/joycaption_model not found in wanly-api/app/config.py")
+    want = m.group(1)
+    assert jc.MODEL == want, f"this image defaults to {jc.MODEL}, wanly-api asks for {want}"
 
 
 class TestAMissingModelIsBuilt:

--- a/tests/test_lora_trainer.py
+++ b/tests/test_lora_trainer.py
@@ -20,6 +20,14 @@ import re
 import pytest
 
 
+def _real_safetensors(path):
+    """A tiny but genuine safetensors file: u64 header length, JSON header, then bytes."""
+    import json
+    import struct
+    header = json.dumps({"w": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}}).encode()
+    path.write_bytes(struct.pack("<Q", len(header)) + header + b"\0" * 4)
+
+
 def _run(coro):
     return asyncio.run(coro)
 
@@ -899,7 +907,7 @@ class TestAFileGoingUpIsNotQueuedAgain:
         out = recipe.run_dir(job.character, job.version) / "output"
         out.mkdir(parents=True)
         f = out / "p@y_v2.comfy.safetensors"
-        f.write_bytes(b"x" * 16)
+        _real_safetensors(f)   # a file with a header, or the sweep refuses it (2026-09-08)
         async def idle(_job):
             return None
         p._upload_worker = idle

--- a/wanly_worker/services/lora_trainer/poller.py
+++ b/wanly_worker/services/lora_trainer/poller.py
@@ -214,6 +214,29 @@ class Poller:
             return True
         return label in self._requested.get(job.id, set())
 
+    @staticmethod
+    def _readable(path: Path) -> bool:
+        """Is this a safetensors file at all? The header is a little-endian u64 length and a
+        JSON blob; a file whose first eight bytes are zero has NO header.
+
+        2026-09-08: the host hard-reset seconds after the final checkpoint was written. ext4
+        kept the file's size and replaced its contents with zeros, the poller's "interrupted
+        run" path uploaded it as Me_v2_final, and every render with that character failed at
+        LoraLoaderModelOnly with "Expecting value: line 1 column 1" -- a JSON error that names
+        nothing. The musubi-format twin beside it was intact. Checked here so a file like that
+        is reported and never published.
+        """
+        try:
+            with path.open("rb") as fh:
+                n = int.from_bytes(fh.read(8), "little")
+                if not 0 < n < 64 * 1024 * 1024:
+                    return False
+                import json
+                json.loads(fh.read(n))
+            return True
+        except Exception:
+            return False
+
     def _settled(self, path: Path) -> bool:
         """Has this file stopped growing? The trainer writes it in place, so a checkpoint that
         is still being written looks like a checkpoint with a smaller size."""
@@ -249,6 +272,13 @@ class Poller:
             if not self._wanted(job, path):
                 continue
             if self._settled(path):
+                if not self._readable(path):
+                    _log(f"!! {path.name} is not a readable safetensors file (no header) — "
+                         f"NOT publishing it. If the host reset right after it was written, "
+                         f"the .safetensors twin beside it is usually intact: regenerate with "
+                         f"musubi_tuner.ltx_2.convert_lora_to_comfy.")
+                    failed.append(str(path))
+                    continue
                 queue.append(path)
         task = self._uploader.get(job.id)
         if queue and (task is None or task.done()):


### PR DESCRIPTION
Incident 2026-09-08: the host hard-reset right after the final `.comfy.safetensors` was written. ext4 kept the file's size and zeroed its contents; the poller's interrupted-run path uploaded it as `Me_v2_final`, and every render with that character failed at `LoraLoaderModelOnly` with a JSON error naming nothing. The musubi-format twin was intact and the ComfyUI file was regenerated from it by hand.

- `Poller._readable(path)`: u64 header length + JSON header parse. A settled file that fails it is logged loudly, recorded in `_failed`, never queued.
- Tests: real header passes, zero-filled and truncated refused, ordering (settled before readable) pinned; the in-flight sweep test now writes a real header.
- The cross-repo `image_description_model` default test parses wanly-api's `Field(...)` form.

Companion: wanly-api's `artifact-commit` reads the header from S3 before recording.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW