### PR TITLE
The trainer's poller gets the box's worker id in one-container mode

### DIFF
--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -168,6 +168,21 @@ class TestTheTrainerDrainsItsOwnRow:
         assert calls == ["http://api/workers/own-id/drain"]
         assert not looked_up
 
+    def test_the_id_file_is_read_at_call_time_from_the_environment(self, tmp_path, monkeypatch):
+        """The control plane exports WORKER_ID_FILE after gpu.py may already be imported."""
+        from wanly_worker.services.lora_trainer import gpu
+        monkeypatch.setattr(gpu, "WORKER_ID_FILE", "")
+        f = tmp_path / "worker-id"; f.write_text("late-id")
+        monkeypatch.setenv("WORKER_ID_FILE", str(f))
+        assert gpu.own_worker_id() == "late-id"
+
+    def test_the_control_plane_exports_the_id_file_for_itself(self):
+        import inspect
+        from wanly_worker import control
+        src = inspect.getsource(control.lifespan)
+        assert 'os.environ["WORKER_ID_FILE"] = WORKER_ID_FILE' in src
+        assert src.index('os.environ["WORKER_ID_FILE"]') < src.index("Supervisor(")
+
     def test_the_poller_reads_the_daemons_id(self):
         import inspect
         from wanly_worker import control

--- a/wanly_worker/control.py
+++ b/wanly_worker/control.py
@@ -45,8 +45,14 @@ async def lifespan(app: FastAPI):
         names = registry.parse_services(os.environ.get("SERVICES"))
         print(f"SERVICES={','.join(names)}", flush=True)
         # Before any child starts: the render daemon reads these from its env and registers
-        # the box with them (one row per box, wanly-gpu-docker#83).
+        # the box with them (one row per box, wanly-gpu-docker#83). WORKER_ID_FILE too, and
+        # for THIS process as much as for the daemon: the trainer's poller and its drain read
+        # the box's own row id from that file, and without the variable in the control
+        # process's env they saw no id and never claimed (Payton v1, first night).
         os.environ.update(export_identity(names))
+        if "ltx-engine" in names:
+            from wanly_worker.services.ltx_engine import WORKER_ID_FILE
+            os.environ["WORKER_ID_FILE"] = WORKER_ID_FILE
         _sup = Supervisor(registry.build(names))
     except Exception as e:
         _fatal(e)

--- a/wanly_worker/services/lora_trainer/gpu.py
+++ b/wanly_worker/services/lora_trainer/gpu.py
@@ -47,11 +47,18 @@ WORKER_ID_FILE = os.environ.get("WORKER_ID_FILE", "")
 
 def own_worker_id() -> str:
     """The id of this box's own worker row, when the render daemon in this container wrote
-    it. Empty on a trainer-only box, which then falls back to finding the render worker."""
-    if not WORKER_ID_FILE:
+    it. Empty on a trainer-only box, which then falls back to finding the render worker.
+
+    READ AT CALL TIME, from the environment, not from the import-time constant: the
+    control plane sets WORKER_ID_FILE for itself (and the daemon child) after parsing
+    SERVICES, and this module can be imported before that. The first night's Payton v1
+    sat in the queue for an hour because the poller saw no worker id and never asked.
+    """
+    path = os.environ.get("WORKER_ID_FILE", "") or WORKER_ID_FILE
+    if not path:
         return ""
     try:
-        return open(WORKER_ID_FILE).read().strip()
+        return open(path).read().strip()
     except OSError:
         return ""
 


### PR DESCRIPTION
First training job on the merged container never claimed: `WORKER_ID_FILE` was in the render daemon's env only, the control process (poller + drain) had none, `own_worker_id()` returned "", and the poller's tick returned before `/training/next`. The file itself was written correctly.

- `control.lifespan` exports `WORKER_ID_FILE` for itself when `ltx-engine` is enabled, before the supervisor starts.
- `gpu.own_worker_id()` reads the path from the environment at call time.
- Tests for both.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW