### PR TITLE
A poll tick with no worker id says so, instead of returning silently

### DIFF
--- a/tests/test_lora_trainer.py
+++ b/tests/test_lora_trainer.py
@@ -1054,3 +1054,71 @@ class TestARunTheRestartInterruptedMidUploadIsFinished:
         assert 'self._patch(job, {"status": "completed"' in src
         # only after the sweep, so a missing final is queued before it is judged
         assert src.index("self._sweep_checkpoints(job)") < src.index('"status": "completed"')
+
+
+class TestATickWithNoWorkerIdIsLoud:
+    """The first night the trainer polled with no worker id and silently returned: the worker
+    row was green and heartbeating, the service answered ready, the store was empty -- and
+    Payton v1 sat pending for an hour while the poll tick said nothing to no one. Every other
+    part of that failure can be seen by proxy; this line is the only thing that says the queue
+    is not empty, the box just cannot ask."""
+
+    def test_a_tick_with_no_id_says_so_and_claims_nothing(self, monkeypatch):
+        from wanly_worker.services.lora_trainer import poller as mod
+        said = []
+        monkeypatch.setattr(mod, "_log", lambda m: said.append(m))
+        p = mod.Poller(client=None, worker_id_getter=lambda: None)
+
+        class C:
+            async def get(self, *a, **k):
+                raise AssertionError("the poll must never reach the API without an id")
+        p._client = C()
+
+        async def go():
+            await p.tick()
+        _run(go())
+        assert said and "no worker id" in said[0]
+
+    def test_the_warning_repeats_on_its_interval_not_every_tick(self, monkeypatch):
+        import time as time_mod
+        from wanly_worker.services.lora_trainer import poller as mod
+        said = []
+        monkeypatch.setattr(mod, "_log", lambda m: said.append(m))
+        p = mod.Poller(client=None, worker_id_getter=lambda: None)
+
+        async def go():
+            await p.tick()
+            await p.tick()
+            await p.tick()
+        real_time = time_mod.time
+        t = [1000.0]
+
+        def fake_time():
+            return t[0]
+        monkeypatch.setattr(mod.time, "time", fake_time)
+        _run(go())
+        assert len(said) == 1
+        # Past the interval, and it is said again -- three silent hours must not be possible.
+        t[0] = 1000.0 + mod.NO_WORKER_ID_LOG_S + 1
+        _run(go())
+        assert len(said) == 2
+
+    def test_a_tick_with_an_id_stays_quiet(self, monkeypatch):
+        from wanly_worker.services.lora_trainer import poller as mod
+        said = []
+        monkeypatch.setattr(mod, "_log", lambda m: said.append(m))
+        p = mod.Poller(client=lambda *a, **k: None, worker_id_getter=lambda: "w")
+        # tick would now call check_publish_requests against a disabled env: QUEUE_URL unset.
+        monkeypatch.setattr(mod, "QUEUE_URL", "")
+        monkeypatch.setattr(mod, "QUEUE_API_KEY", "")
+        app_mod = __import__("wanly_worker.services.lora_trainer.app", fromlist=["STORE"])
+
+        class NowhereStore:
+            def claim_slot(self):
+                return False
+        monkeypatch.setattr(app_mod, "STORE", NowhereStore())
+
+        async def go():
+            await p.tick()
+        _run(go())
+        assert said == []

--- a/wanly_worker/services/lora_trainer/poller.py
+++ b/wanly_worker/services/lora_trainer/poller.py
@@ -40,6 +40,11 @@ EPOCH_RE = re.compile(r"-(\d+)\.comfy\.safetensors$")
 #: what makes a request satisfiable, and those are not cleaned up, but polling every job
 #: this box ever trained on every tick is not free either.
 PUBLISH_WATCH_DAYS = int(os.environ.get("PUBLISH_WATCH_DAYS", "14"))
+#: How often the no-worker-id warning repeats. A tick with no id must SAY SO -- a silent
+#: return is invisible behind an entirely healthy-looking box, which is how Payton v1 sat in
+#: the queue for an hour on its first night. Repeating because docker logs are not
+#: necessarily watched as they happen.
+NO_WORKER_ID_LOG_S = int(os.environ.get("NO_WORKER_ID_LOG_S", "300"))
 
 
 def _log(msg: str) -> None:
@@ -82,6 +87,8 @@ class Poller:
         #: fact -- the two things that decide which of the files on disk are wanted.
         self._policy: dict[str, str] = {}
         self._requested: dict[str, set[str]] = {}
+        #: When the no-worker-id warning was last said, so the loud tick is not a flood.
+        self._no_id_said_at: float = 0.0
 
     def start(self) -> None:
         if not enabled():
@@ -107,6 +114,16 @@ class Poller:
     async def tick(self) -> None:
         wid = self._worker_id()
         if not wid:
+            # SAY WHY, then say it again every few minutes. Every other part of a broken
+            # claim path can be seen by asking elsewhere -- the row is green, the service
+            # is ready, the store is idle -- so this line is the ONLY thing that tells
+            # "the queue is empty" apart from "this box can never ask".
+            if time.time() - self._no_id_said_at >= NO_WORKER_ID_LOG_S:
+                _log("no worker id — NOT claiming any work. In one-container mode the render "
+                     "daemon owns the row and writes its id to WORKER_ID_FILE; if this keeps "
+                     "appearing while the worker row is registered, the control plane never "
+                     "saw that id.")
+                self._no_id_said_at = time.time()
             return
         await self.check_publish_requests()
         # Do not even ask while busy. Claiming marks the row on the API side, so asking for work


### PR DESCRIPTION
Closes #91. Companion to #90, which exported `WORKER_ID_FILE` for the control process.

## The remaining half of the Payton v1 night

#90 fixes *why* the tick had no id. This closes the *silent* part: `tick()` returned before asking **and before logging**, so a claim loop that could never ask looked identical to an empty queue — behind a green, heartbeating worker row, a ready trainer service and an empty store. Every other failure in this path is visible by proxy; this line was the only one that answered "is the queue empty, or can this box never ask?". Nothing did.

## What

- No-id tick logs `no worker id — NOT claiming any work…`, repeating every 5 min (`NO_WORKER_ID_LOG_S`) rather than every tick: docker logs are read later, not watched.
- Tests: the warning is said, claimed-nothing is asserted (the poll never reaches the API), the repeat is interval-bound *past* the interval, and an id-having tick stays quiet.

## Verified the tests catch the bug

Checked out the pre-fix sources (`81d0f35`) with the new tests in place: both loud-tick tests and both of #90's id-file tests **fail** (4 failed); restored: 344 passed, 2 warnings.