### PR TITLE
The worker takes its GPU through CDI, and a failed first allocation says "lost access" (#95)

### DIFF
--- a/deploy/run-worker.sh
+++ b/deploy/run-worker.sh
@@ -114,10 +114,16 @@ docker rm -f "$NAME" >/dev/null 2>&1 || true
 
 # COMFYUI_PATH is EMPTY on purpose — see the note in start.sh. With a path set the daemon
 # takes ownership of ComfyUI's custom nodes, which breaks an LTX worker.
+# CDI, NOT `--gpus all` (#95). With `--gpus all` the toolkit hook grants the GPU device nodes
+# outside the container's OCI spec, so the next `systemctl daemon-reload` re-applies the
+# spec's device rules WITHOUT them: every CUDA allocation then fails with "0 bytes allocated,
+# 23 GiB free" until the container is recreated. Seen 2026-09-10, six minutes after a reboot.
+# CDI (`/var/run/cdi/nvidia.yaml`, kept fresh by nvidia-cdi-refresh) puts the devices in the
+# spec itself, where a reload preserves them. Needs Docker >= 28 and the toolkit's CDI spec.
 docker run -d \
     --name "$NAME" \
     --restart unless-stopped \
-    --gpus all \
+    --device nvidia.com/gpu=all \
     --shm-size "$SHM_SIZE" \
     -p "${COMFY_HOST_PORT:-8191}:8188" \
     -p "${ENGINE_HOST_PORT:-8190}:8190" \

--- a/engine/app.py
+++ b/engine/app.py
@@ -54,6 +54,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 import comfy
+import failure as failure_mod
 import purge as purge_mod
 import recipe as recipe_mod
 import ltx_grid
@@ -925,14 +926,10 @@ def run_job(job: Job):
         job.status = "Done"
         print(f"[{job.id}] done in {time.time() - job.started:.0f}s -> {out}", flush=True)
     except Exception as e:
-        msg = f"{type(e).__name__}: {e}"
-        if "OOM" in msg or "out of memory" in msg.lower():
-            # The card is 24 GB and shared. Say what to change rather than
-            # returning torch's allocator dump.
-            msg += (f" — {job.req.width}x{job.req.height} at {job.req.num_frames} "
-                    f"frames did not fit. Reduce resolution or frame count; "
-                    f"704x1280 at 241 frames is known to fit alongside the other "
-                    f"resident containers.")
+        # An OOM is rewritten into advice -- but "0 bytes allocated" is not an OOM, it is
+        # the container having lost the GPU, and the advice must say so (#95).
+        msg = failure_mod.explain_failure(f"{type(e).__name__}: {e}", job.req.width,
+                                          job.req.height, job.req.num_frames)
         job.status, job.error = "Failed", msg
         print(f"[{job.id}] FAILED: {job.error}", flush=True)
     finally:

--- a/engine/failure.py
+++ b/engine/failure.py
@@ -1,0 +1,42 @@
+"""What to tell the caller when a render dies (wanly-gpu-docker#95).
+
+Torch's allocator dump is not an explanation, so the engine has always rewritten an OOM into
+"reduce resolution or frame count". That advice was WRONG on 2026-09-10: every render on the
+3090 died on its first 384 KiB allocation with 23 GiB free, because the container had lost
+its GPU device access after a systemd reload, and the rewrite blamed 1216x832 -- a size that
+had rendered dozens of times. Pure, so the two signatures can be asserted without a GPU.
+"""
+import re
+
+#: Torch's dump when the process could not allocate ANYTHING. A real out-of-memory reports
+#: gigabytes already allocated; zero means the device refused the very first request.
+_NOTHING_ALLOCATED = re.compile(r"Currently allocated\s*:\s*0 bytes")
+#: What a fresh process says once the device cgroup rules are gone.
+_NO_DEVICE = ("No CUDA GPUs are available", "Failed to initialize NVML",
+              "CUDA-capable device(s) is/are busy or unavailable", "cudaErrorNoDevice")
+
+
+def lost_gpu_access(msg: str) -> bool:
+    """True when the failure is "cannot touch the GPU at all", not "the GPU is full"."""
+    return bool(_NOTHING_ALLOCATED.search(msg)) or any(s in msg for s in _NO_DEVICE)
+
+
+def explain_failure(msg: str, width: int, height: int, num_frames: int) -> str:
+    """The error as the caller should read it.
+
+    Two very different failures both print "out of memory". Distinguish them, because the
+    remedies are opposites: one is "ask for less", the other is "restart the container".
+    """
+    if lost_gpu_access(msg):
+        return (msg + " — the process could not allocate on the GPU at all (0 bytes held), "
+                "which is lost GPU device access, not a full card: it happens when systemd "
+                "reloads after the container started (wanly-gpu-docker#95). Check with "
+                "`head -c1 /dev/nvidiactl` inside the container ('Operation not permitted' "
+                "confirms it) and restart the container. Do NOT reduce resolution.")
+    if "OOM" in msg or "out of memory" in msg.lower():
+        # The card is 24 GB and shared. Say what to change rather than returning torch's
+        # allocator dump.
+        return (msg + f" — {width}x{height} at {num_frames} frames did not fit. Reduce "
+                "resolution or frame count; 704x1280 at 241 frames is known to fit alongside "
+                "the other resident containers.")
+    return msg

--- a/tests/test_failure_message.py
+++ b/tests/test_failure_message.py
@@ -1,0 +1,34 @@
+"""The engine's failure rewrite tells lost GPU access apart from a full card (#95)."""
+from engine.failure import explain_failure, lost_gpu_access
+
+REAL_OOM = ("OutOfMemoryError: CUDA out of memory. Tried to allocate 2.50 GiB. GPU 0 has a total "
+            "capacity of 23.56 GiB of which 1.10 GiB is free. Including non-PyTorch memory, this "
+            "process has 21.9 GiB memory in use.")
+LOST_ACCESS = ("ComfyError: execution failed: Allocation on device 0 would exceed allowed memory. "
+               "(out of memory)\nCurrently allocated     : 0 bytes\nRequested               : "
+               "384.00 KiB\nDevice limit            : 23.56 GiB\nFree (according to CUDA): 23.28 GiB")
+
+
+def test_a_real_oom_still_says_reduce_the_render():
+    out = explain_failure(REAL_OOM, 1216, 832, 241)
+    assert "1216x832 at 241 frames did not fit" in out
+    assert "device access" not in out
+
+
+def test_zero_bytes_allocated_is_lost_access_not_a_full_card():
+    """The 2026-09-10 signature: first 384 KiB refused with 23 GiB free."""
+    out = explain_failure(LOST_ACCESS, 1216, 832, 241)
+    assert "lost GPU device access" in out
+    assert "/dev/nvidiactl" in out
+    assert "did not fit" not in out, "blamed the resolution for a card it could not reach"
+
+
+def test_a_fresh_process_with_no_device_is_lost_access():
+    assert lost_gpu_access("RuntimeError: No CUDA GPUs are available")
+    assert lost_gpu_access("Failed to initialize NVML: Unknown Error")
+    assert not lost_gpu_access(REAL_OOM)
+
+
+def test_anything_else_is_passed_through():
+    assert explain_failure("RuntimeError: ComfyUI finished but produced no video", 704, 1280, 241) \
+        == "RuntimeError: ComfyUI finished but produced no video"

--- a/tests/test_worker_deploy.py
+++ b/tests/test_worker_deploy.py
@@ -44,8 +44,13 @@ class TestTheContainerSpecIsComplete:
     def test_it_survives_a_reboot(self):
         assert "--restart unless-stopped" in RUN.read_text()
 
-    def test_it_gets_the_gpu(self):
-        assert "--gpus all" in RUN.read_text()
+    def test_it_gets_the_gpu_through_cdi(self):
+        """`--gpus all` grants the device nodes outside the OCI spec, and a systemd reload
+        takes them away again (#95). CDI puts them in the spec, where a reload keeps them."""
+        s = RUN.read_text()
+        assert "--device nvidia.com/gpu=all" in s
+        # As a FLAG. The comment above the run block names the old one to explain why.
+        assert not re.search(r"^\s*--gpus\b", s, re.M)
 
     def test_comfyui_path_is_explicitly_empty(self):
         """Not merely absent. With a path set the daemon takes ownership of ComfyUI's custom


### PR DESCRIPTION
Closes #95. Targets `next` because the 3090 runs `:next-full`.

## The container flag

`--gpus all` → `--device nvidia.com/gpu=all` in `deploy/run-worker.sh`. With `--gpus all` the toolkit hook grants the device nodes outside the OCI spec, and a `systemctl daemon-reload` re-applies the spec's device rules without them. From then on every CUDA allocation fails with "Currently allocated: 0 bytes … Free: 23 GiB" until the container is recreated. CDI puts the devices in the spec itself.

Verified on the 3090 before writing this: `docker run --rm --device nvidia.com/gpu=all --entrypoint nvidia-smi davidjbarnes/wanly-gpu-docker:next-full -L` sees the card. No root and no daemon.json change needed: Docker 29.2, toolkit 1.19, `/var/run/cdi/nvidia.yaml` kept fresh by `nvidia-cdi-refresh.path`.

## The engine message

`engine/failure.py`: `explain_failure()` tells lost GPU access (zero bytes allocated, or "No CUDA GPUs are available" / NVML init failure) apart from a real OOM. The first now says to check `/dev/nvidiactl` inside the container and restart it; the second keeps the "reduce resolution" advice. Pure module, tested without a GPU.

## Deploy

The host checkout at `/home/david/wanly-gpu-docker` (branch `next`) has to `git pull` for the new run flags, and the timer recreates the container when the `:next-full` build lands. The proof that the fix holds is a `sudo systemctl daemon-reload` on the box followed by `docker exec wanly-gpu-docker nvidia-smi -L` still answering.

`pytest tests/`: 348 passed. `bash -n deploy/run-worker.sh` clean.

https://claude.ai/code/session_01EtkWwkD41G2TfmnXfm2YXK