### PR TITLE
update-worker.sh takes a lock: concurrent runs no longer race on rm/run

### DIFF
--- a/deploy/update-worker.sh
+++ b/deploy/update-worker.sh
@@ -13,9 +13,29 @@
 # WHY IT COMPARES DIGESTS, NOT TAGS
 #     :latest is a moving pointer. "Am I on latest?" is only answerable by comparing the
 #     digest the container was created from against the digest the tag resolves to NOW.
+#
+# WHY IT LOCKS (wanly-gpu-docker#97)
+#     Two copies of this script running at once — a manual run while a timer run is mid-pull,
+#     which is 13 GiB and ~11 minutes on the 3090's link, so the window is wide — both see
+#     "image changed" and both run run-worker.sh. One wins; another dies on a container-name
+#     conflict, or worse removes the winner's container between its rm -f and its run.
+#     flock -n makes the loser exit 0 with a message instead: stacked firings are made
+#     harmless rather than impossible. The FD stays open for the script's whole life,
+#     including the `exec run-worker.sh` paths, so it covers the spawn too.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# /run/user/$UID exists on a normal login ($XDG_RUNTIME_DIR points there); /run/lock as a
+# fallback for cron-style contexts where it does not.
+LOCK_DIR="${XDG_RUNTIME_DIR:-/run/lock}"
+LOCK_FILE="$LOCK_DIR/wanly-worker-update.lock"
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) another update is in progress — nothing to do"
+    exit 0
+fi
+
 IMAGE="${IMAGE:-davidjbarnes/wanly-gpu-docker:latest}"
 NAME="${NAME:-wanly-gpu-docker}"
 

--- a/tests/test_worker_deploy.py
+++ b/tests/test_worker_deploy.py
@@ -226,6 +226,82 @@ class TestTheDecision:
         assert "assuming busy" in r.stdout
 
 
+class TestTheLock:
+    """wanly-gpu-docker#97.
+
+    Seen 2026-09-10 while deploying #96: a manual update was mid-pull (13 GiB, ~11 min) when
+    the timer fired twice more. Three copies all saw "image changed" and all ran
+    run-worker.sh; one died on a container-name conflict, and a loser could have removed the
+    winner's container between its rm -f and its run.
+    """
+
+    SAME = "sha256:aaa"
+    NEW = "sha256:bbb"
+
+    def _run_two(self, tmp_path, hold_before_run=None):
+        """Fire two copies concurrently against the same lock and return both results."""
+        import subprocess
+        bin_dir, stage = _stage(tmp_path, running_image=self.SAME, latest_image=self.NEW,
+                                engine_busy=0, worker_status="online-idle")
+        env = dict(os.environ, PATH="%s:%s" % (bin_dir, os.environ["PATH"]))
+
+        script = stage / "update-worker.sh"
+        first = subprocess.Popen(["bash", str(script)], stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT, text=True, env=env)
+        second = subprocess.Popen(["bash", str(script)], stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT, text=True, env=env)
+        first.wait(timeout=30)
+        second.wait(timeout=30)
+        return first.stdout.read(), second.stdout.read(), first.returncode, second.returncode
+
+    def test_a_concurrent_run_exits_zero_without_recreating(self, tmp_path):
+        """The loser must not die on a name conflict, and must not recreate: stacked firings
+        are made harmless rather than trying to make them impossible."""
+        out_a, out_b, code_a, code_b = self._run_two(tmp_path)
+        recreated = [o for o in (out_a, out_b) if "RECREATED" in o]
+        refused = [o for o in (out_a, out_b) if "another update is in progress" in o]
+
+        assert len(recreated) == 1, (out_a, out_b)
+        assert len(refused) == 1, (out_a, out_b)
+        loser_code = code_b if "RECREATED" in out_a else code_a
+        assert loser_code == 0, "the loser must exit 0, not a timer-visible failure"
+
+    def test_the_lock_is_held_while_run_worker_spawns(self, tmp_path):
+        """The lock must still be held when run-worker.sh runs — that is the window where a
+        loser could have rm -f'd the winner's container between its rm and its run.
+
+        flock -n 9 inside the child proves nothing: fd 9 is inherited and points at the SAME
+        open file description, so flock trivially "succeeds" against its own lock. The
+        honest check is a FRESH open of the lock file from an unrelated process.
+        """
+        import subprocess
+        bin_dir, stage = _stage(tmp_path, running_image=self.SAME, latest_image=self.NEW,
+                                engine_busy=0, worker_status="online-idle")
+        # A fresh open of the lock file (flock <file> opens its own fd) from INSIDE the
+        # child, so it competes with the parent's held lock like any third party would.
+        (stage / "run-worker.sh").write_text(
+            "#!/usr/bin/env bash\n"
+            'lock="${XDG_RUNTIME_DIR:-/run/lock}/wanly-worker-update.lock"\n'
+            'if flock -n "$lock" true; then echo "LOCK-FREE"; else echo "LOCK-HELD"; fi\n'
+        )
+        (stage / "run-worker.sh").chmod(0o755)
+        env = dict(os.environ, PATH="%s:%s" % (bin_dir, os.environ["PATH"]))
+
+        r = subprocess.run(["bash", str(stage / "update-worker.sh")],
+                           capture_output=True, text=True, env=env)
+        assert "LOCK-HELD" in r.stdout, r.stdout
+        assert "LOCK-FREE" not in r.stdout
+
+    def test_serial_runs_do_not_deadlock(self, tmp_path):
+        """A lock that never released would turn the timer into a no-op forever — the
+        installed-and-dead failure from #72, again."""
+        r1 = _run(tmp_path, running_image=self.SAME, latest_image=self.NEW)
+        assert "RECREATED" in r1.stdout
+        r2 = _run(tmp_path, running_image=self.NEW, latest_image=self.NEW)
+        assert r2.returncode == 0
+        assert "nothing to do" in r2.stdout
+
+
 def test_the_scripts_are_executable():
     for p in (RUN, UPDATE):
         assert os.stat(p).st_mode & stat.S_IXUSR, "%s is not executable" % p.name


### PR DESCRIPTION
Closes #97.

## Why

Seen 2026-09-10 while deploying #96: a manual `deploy/update-worker.sh` was mid-pull (13 GiB, ~11 min on the 3090's link) when the timer fired twice more. Three copies all saw "image changed" and all ran `run-worker.sh`. One won; another died on a container-name conflict, and a loser could just as easily have removed the winner's container *between* its `rm -f` and its `run` — recreating it from the wrong image with no record.

## What

- The script body holds `flock -n` on `/run/user/$UID/wanly-worker-update.lock` (fd 9, open for the script's whole life including the `exec run-worker.sh` paths) — a loser exits 0 with "another update is in progress": stacked firings are made harmless rather than trying to make them impossible.
- **The timer is deliberately untouched.** Making the cadence "count from the end of the last run" (as the issue suggests) would regress into #72's installed-and-dead timer — `OnUnitActiveSec` without `OnBootSec` already silently stopped scheduling once. `OnCalendar` always has a next elapse; the lock makes a second firing harmless instead of trying to make one impossible.

## Verification

- `tests/test_worker_deploy.py` — 113 passed (3 new in `TestTheLock`):
  - Two concurrent invocations against the same lock (the manual-plus-timer race) produce exactly one `RECREATED` and one refusal, and the refusal **exits 0** rather than a timer-visible failure.
  - A fresh `flock` of the lock file from inside the spawned `run-worker.sh` shows it still held during the recreate window.
  - Serial runs don't deadlock — the second run proceeds to "nothing to do".
- One test-infrastructure catch: `flock -n 9` inside the child proves nothing — fd 9 is inherited and points at the *same* open file description, so the probe trivially succeeds against its own lock. The staged `run-worker.sh` opens the lock file fresh instead, competing like any third party would.
- `bash -n` clean; repo-wide ruff unchanged (pre-existing errors in `engine/`, untouched).