### PR TITLE
Joint two-identity training: per-group stage + two-entry dataset toml

### DIFF
--- a/tests/test_lora_trainer.py
+++ b/tests/test_lora_trainer.py
@@ -11,8 +11,6 @@ this project real time:
     reader shows nothing for fifty minutes and a healthy run looks hung.
 """
 import asyncio
-import os
-import tempfile
 from pathlib import Path
 
 import re
@@ -764,7 +762,7 @@ class TestTheWaitForTheCardIsReported:
         import inspect
         from wanly_worker.services.lora_trainer import app as mod
         src = inspect.getsource(mod._run)
-        stage = src.index("await pipeline.stage(job, images, req.caption)")
+        stage = src.index("run = await pipeline.stage(job, groups)")
         acquire = src.index("await gpu.acquire(client, HOSTNAME")
         assert "await on_progress(job)" in src[stage:acquire]
 
@@ -1122,3 +1120,59 @@ class TestATickWithNoWorkerIdIsLoud:
             await p.tick()
         _run(go())
         assert said == []
+
+
+class TestTheJointRun:
+    """A joint two-identity run (wanly-gpu-docker#102): ONE LoRA trained on both identity
+    groups at once. Per-group captions and dirs, a two-entry dataset toml, and the
+    single-identity shape byte-unchanged — the toml is the regression trail."""
+
+    def test_single_identity_toml_is_unchanged(self):
+        from wanly_worker.services.lora_trainer.recipe import dataset_toml
+        toml = dataset_toml(Path("/tmp/r"))
+        assert toml.count("[[datasets]]") == 1
+        # The bare dirs, exactly as before #102.
+        assert 'image_directory = "/tmp/r/data"' in toml
+        assert 'cache_directory = "/tmp/r/cache"' in toml
+        # No numbered dirs in the single-identity shape.
+        assert "data0" not in toml and "data1" not in toml
+
+    def test_joint_toml_has_one_entry_per_group(self):
+        from wanly_worker.services.lora_trainer.recipe import dataset_toml
+        toml = dataset_toml(Path("/tmp/r"), groups=[
+            {"data": "/tmp/r/data", "cache": "/tmp/r/cache", "num_repeats": 10},
+            {"data": "/tmp/r/data1", "cache": "/tmp/r/cache1", "num_repeats": 10},
+        ])
+        assert toml.count("[[datasets]]") == 2
+        assert 'image_directory = "/tmp/r/data1"' in toml
+        assert 'cache_directory = "/tmp/r/cache1"' in toml
+
+    def test_stage_writes_per_group_captions(self, monkeypatch, tmp_path):
+        """Group 1's images caption GROUP 1's trigger — group 0's would bind the second
+        face to the wrong person's token, and the interference this run exists to escape
+        would arrive through the captions instead."""
+        import asyncio
+        from wanly_worker.services.lora_trainer import pipeline
+        from wanly_worker.services.lora_trainer.jobs import Job
+
+        monkeypatch.setattr(pipeline.recipe, "RUNS_DIR", str(tmp_path))
+        job = Job(id="j1", character="pay", trigger="p@y", version=1, steps=1200)
+        img0 = [(f"a{i}.jpg", b"x") for i in range(2)]
+        img1 = [(f"b{i}.jpg", b"y") for i in range(2)]
+        run = asyncio.run(pipeline.stage(job, [
+            {"images": img0, "caption": "p@y, woman", "num_repeats": 10},
+            {"images": img1, "caption": "d@vid, man", "num_repeats": 10},
+        ]))
+        assert (run / "data" / "sel_000.txt").read_text() == "p@y, woman\n"
+        assert (run / "data1" / "sel_000.txt").read_text() == "d@vid, man\n"
+        toml = (run / "dataset.toml").read_text()
+        assert toml.count("[[datasets]]") == 2
+        assert 'image_directory = "%s/data1"' % run in toml
+
+    def test_joint_poller_map_carries_the_second_group(self):
+        """The claim's second_* land in the TrainRequest; absent stays absent."""
+        import inspect
+        from wanly_worker.services.lora_trainer import poller as mod
+        src = inspect.getsource(mod.Poller.tick)
+        assert "second_download_urls" in src
+        assert "second_identity" in src

--- a/wanly_worker/services/lora_trainer/app.py
+++ b/wanly_worker/services/lora_trainer/app.py
@@ -41,6 +41,12 @@ class TrainRequest(BaseModel):
     image_urls: list[str] = Field(default_factory=list)
     image_dir: str = ""
     caption: str | None = None
+    #: THE JOINT GROUP (#102). ABSENT means single-identity, which every run before this
+    #: is. One entry: {character, trigger, gender, image_urls, num_repeats} -- the second
+    #: dataset's URLs presigned by the API alongside group 0's, its caption resolved by
+    #: the same rule that made group 0's trigger carry. The claim builds it; a POST body
+    #: may also give it directly.
+    second_identity: dict | None = None
     steps: int = Field(default=1200, ge=100, le=6000)
     config: dict = Field(default_factory=dict)
     remote_id: str = ""
@@ -184,8 +190,37 @@ async def _run(job: Job, req: TrainRequest, on_progress=None) -> None:
                 raise pipeline.PipelineError("no images to train on")
             job.images = len(images)
 
+            # ONE ENTRY PER IDENTITY GROUP. Group 0 is the job's own character; the joint
+            # group (#102) rides req.second_identity with its own URLs, caption and
+            # repeats. The stage call takes the list so per-group captions and dirs stay
+            # paired -- two separate stage calls would mean two dataset.toml writes, and
+            # the last one would win.
+            groups = [{"images": images, "caption": req.caption,
+                       "num_repeats": (req.config or {}).get("num_repeats")
+                       or recipe.DEFAULTS["num_repeats"]}]
+            if req.second_identity:
+                si = req.second_identity
+                second_urls = si.get("image_urls") or []
+                if not second_urls and si.get("image_dir"):
+                    d = Path(si["image_dir"])
+                    second_images = [(f.name, f.read_bytes()) for f in sorted(d.iterdir())
+                                     if f.suffix.lower() in {".jpg", ".jpeg", ".png", ".webp"}]
+                else:
+                    second_images = await _fetch(client, second_urls)
+                if not second_images:
+                    raise pipeline.PipelineError("no second-identity images to train on")
+                groups.append({
+                    "images": second_images,
+                    "caption": si.get("caption"),
+                    "num_repeats": si.get("num_repeats")
+                    or recipe.DEFAULTS["num_repeats"],
+                })
+                job.images += len(second_images)
+                # The disk gate reads repeats x total images; a joint run's both groups
+                # count, and mixed repeats across groups would make the estimate a guess.
+                job.effective_repeats = max(g["num_repeats"] for g in groups)
             pipeline.preflight(job)
-            run = await pipeline.stage(job, images, req.caption)
+            run = await pipeline.stage(job, groups)
             # SAY SO. Nothing reported between the claim and the first training step left the
             # API row at "claimed" with no progress for the whole of staging and the drain
             # wait -- which reads as queued in the console, and which the orphan reclaim

--- a/wanly_worker/services/lora_trainer/jobs.py
+++ b/wanly_worker/services/lora_trainer/jobs.py
@@ -30,6 +30,9 @@ class Job:
     version: int
     steps: int
     images: int = 0
+    #: The repeats the disk estimate applies: max across identity groups (#102). None for
+    #: single-identity runs, where recipe.DEFAULTS applies — the same estimate as before.
+    effective_repeats: int | None = None
     #: pending | staging | training | collecting | completed | failed | cancelled
     phase: str = "pending"
     step: int = 0

--- a/wanly_worker/services/lora_trainer/pipeline.py
+++ b/wanly_worker/services/lora_trainer/pipeline.py
@@ -56,7 +56,8 @@ def preflight(job: Job) -> None:
             f"no trainer at {recipe.TRAINER_PYTHON} — this image was built without "
             f"WITH_TRAINER=1")
 
-    epochs = recipe.estimated_epochs(job.images, job.steps)
+    epochs = recipe.estimated_epochs(job.images, job.steps,
+                                     repeats=getattr(job, "effective_repeats", None))
     need = epochs * GB_PER_EPOCH
     free = shutil.disk_usage(recipe.RUNS_DIR).free / 1024 ** 3
     if free < need + 5:
@@ -65,8 +66,13 @@ def preflight(job: Job) -> None:
             f"free under {recipe.RUNS_DIR}")
 
 
-async def stage(job: Job, images: list[tuple[str, bytes]], caption: str | None) -> Path:
-    """Write the dataset and the config. Returns the run directory.
+async def stage(job: Job, groups: list[dict]) -> Path:
+    """Write the dataset(s) and the config. Returns the run directory.
+
+    `groups` is one entry per identity: {images: [(name, bytes)], caption, num_repeats}.
+    ONE entry is the single-identity shape every run before #102 wrote — same directories
+    (`data/`, `cache/`), same toml bytes. A joint run writes `data0/`+`cache0/`,
+    `data1/`+`cache1/`, per-group captions and a two-entry toml.
 
     The run directory is REBUILT, not added to. A version that reuses a directory trains on the
     previous version's leftover images while reporting the new count -- the failure
@@ -78,16 +84,32 @@ async def stage(job: Job, images: list[tuple[str, bytes]], caption: str | None) 
     for sub in ("data", "cache", "output", "logs"):
         (run / sub).mkdir(parents=True, exist_ok=True)
 
-    _log(job, f"staging {len(images)} images")
-    for i, (name, blob) in enumerate(images):
-        ext = Path(name).suffix.lower() or ".jpg"
-        (run / "data" / f"sel_{i:03d}{ext}").write_bytes(blob)
-        # Captions bind whatever they do not name. All 13 of p@y's read "p@y, woman" over
-        # close-ups, so the trigger carried close-up framing as part of its identity.
-        (run / "data" / f"sel_{i:03d}.txt").write_text(
-            (caption or f"{job.trigger}, woman") + "\n")
+    toml_groups = []
+    for gi, g in enumerate(groups):
+        # Group 0 keeps the bare dirs so a single-identity run hashes and stages exactly
+        # as it always has; joint groups get numbered ones, which cannot collide with a
+        # pre-existing bare dir after the rebuild above.
+        data_dir = run / "data" if gi == 0 else run / f"data{gi}"
+        cache_dir = run / "cache" if gi == 0 else run / f"cache{gi}"
+        if gi > 0:
+            data_dir.mkdir(parents=True, exist_ok=True)
+            cache_dir.mkdir(parents=True, exist_ok=True)
 
-    (run / "dataset.toml").write_text(recipe.dataset_toml(run))
+        _log(job, f"staging group {gi}: {len(g['images'])} images "
+                  f"({g['num_repeats']} repeats)")
+        for i, (name, blob) in enumerate(g["images"]):
+            ext = Path(name).suffix.lower() or ".jpg"
+            (data_dir / f"sel_{i:03d}{ext}").write_bytes(blob)
+            # Captions bind whatever they do not name. All 13 of p@y's read "p@y, woman" over
+            # close-ups, so the trigger carried close-up framing as part of its identity.
+            # PER GROUP: a joint run's group 1 must say its OWN trigger, or its face binds
+            # to whatever the text happens to be.
+            (data_dir / f"sel_{i:03d}.txt").write_text(
+                (g["caption"] or f"{job.trigger}, woman") + "\n")
+        toml_groups.append({"data": str(data_dir), "cache": str(cache_dir),
+                            "num_repeats": g["num_repeats"]})
+
+    (run / "dataset.toml").write_text(recipe.dataset_toml(run, toml_groups))
     return run
 
 

--- a/wanly_worker/services/lora_trainer/poller.py
+++ b/wanly_worker/services/lora_trainer/poller.py
@@ -142,10 +142,22 @@ class Poller:
             return
 
         _log(f"claimed {row['character']} v{row['version']} ({len(row['download_urls'])} images)")
+        # THE JOINT GROUP (#102). second_* ride the claim response only for a joint run;
+        # ABSENT for every single-identity job, so this maps to None and the trainer's
+        # stage() writes the one-group shape it always has.
+        second = None
+        if row.get("second_download_urls"):
+            second = {
+                "character": row.get("config", {}).get("second_character"),
+                "image_urls": row["second_download_urls"],
+                "caption": row.get("second_caption"),
+                "num_repeats": row.get("second_num_repeats"),
+            }
         req = trainer_app.TrainRequest(
             character=row["character"], trigger=row["trigger"], version=row["version"],
             image_urls=row["download_urls"],
             caption=(row.get("config") or {}).get("caption"),
+            second_identity=second,
             steps=(row.get("config") or {}).get("steps") or 1200,
             config=row.get("config") or {},
             remote_id=row["id"],

--- a/wanly_worker/services/lora_trainer/recipe.py
+++ b/wanly_worker/services/lora_trainer/recipe.py
@@ -71,18 +71,34 @@ def run_dir(character: str, version: int) -> Path:
     return Path(RUNS_DIR) / character / f"ltx23b-v{version}"
 
 
-def dataset_toml(run: Path) -> str:
+def dataset_toml(run: Path, groups: list[dict] | None = None) -> str:
+    """The dataset config. One `[[datasets]]` entry per identity group.
+
+    `groups` absent (or one entry) is the single-identity shape every run before #102
+    wrote, byte-identical — the toml is the regression trail and a single run must not
+    look different. A joint run (#102) writes one entry per group, each with its OWN
+    data + cache directory and its own num_repeats: the repeats balance the two sets
+    (Payton 55 images vs David 50), and per-dataset dirs keep the caches separate
+    because a cache is latents for specific images + captions — sharing one across
+    groups would pair group 1's latents with group 0's cached text outputs.
+    """
+    if not groups:
+        groups = [{"data": f"{run}/data", "cache": f"{run}/cache",
+                   "num_repeats": DEFAULTS["num_repeats"]}]
+    entries = "\n\n".join(
+        f'[[datasets]]\n'
+        f'image_directory = "{g["data"]}"\n'
+        f'cache_directory = "{g["cache"]}"\n'
+        f'resolution = [{DEFAULTS["resolution"]}, {DEFAULTS["resolution"]}]\n'
+        f'num_repeats = {g["num_repeats"]}'
+        for g in groups)
     return f"""[general]
 caption_extension = ".txt"
 batch_size = 1
 enable_bucket = true
 bucket_no_upscale = true
 
-[[datasets]]
-image_directory = "{run}/data"
-cache_directory = "{run}/cache"
-resolution = [{DEFAULTS['resolution']}, {DEFAULTS['resolution']}]
-num_repeats = {DEFAULTS['num_repeats']}
+{entries}
 """
 
 
@@ -141,8 +157,9 @@ def train_cmd(run: Path, character: str, version: int, config: dict) -> list[str
     ]
 
 
-def estimated_epochs(image_count: int, steps: int) -> int:
+def estimated_epochs(image_count: int, steps: int, repeats: int | None = None) -> int:
     """num_repeats is fixed, so this is not steps/1200 -- it is how many passes over each image
-    the run will actually make."""
-    per_epoch = max(1, image_count * DEFAULTS["num_repeats"])
+    the run will actually make. A joint run's count is BOTH groups' images summed (the
+    caller passes the total), with the repeats that apply to them."""
+    per_epoch = max(1, image_count * (repeats or DEFAULTS["num_repeats"]))
     return max(1, steps // per_epoch)


### PR DESCRIPTION
Trainer side of #102 (API: wanly-api#313, console: wanly-console dual-character PR).

## Why

R2 (#100) proved no weight setting recovers two-char identity — the fix is a joint run: ONE LoRA trained on both identity groups at once. The trainer learns it from the API's claim response.

## What

- `stage()` takes **one entry per identity group** — `{images, caption, num_repeats}` — so per-group captions and dirs stay paired. Group 0 keeps the bare `data/`/`cache/` dirs (single-identity staging unchanged); joint groups get `data1/`+`cache1/`.
- **Group 1's images caption GROUP 1's trigger** — the per-job fallback carries group 0's, and the second face would bind to the wrong person's token.
- `dataset.toml` gains one `[[datasets]]` entry per group, each with its own `num_repeats` (the repeats balance 55 vs 50) and its own cache dir (a cache is latents + cached text for specific images — sharing one across groups would pair group 1's latents with group 0's cached text). **Single-identity toml bytes unchanged** — the toml is the regression trail.
- The poller maps the claim's `second_*` into the TrainRequest; absent stays absent, so a trainer that predates this writes the one-group shape it always has.
- The disk gate counts both groups at the max repeats — mixed repeats would make the estimate a guess.

## Verification

- 4 new tests: single-identity toml unchanged (no numbered dirs), joint toml = 2 entries with data1/cache1, per-group captions land (`d@vid, man` in data1 while `p@y, woman` in data), poller map carries the second group.
- Full suite **356 passed**.
- Console side: wanly-console dual-character PR (TrainLoraDialog toggle).