### PR TITLE
Trainer: stage N groups, identity or composition

### DIFF
--- a/tests/test_lora_trainer.py
+++ b/tests/test_lora_trainer.py
@@ -1169,10 +1169,38 @@ class TestTheJointRun:
         assert toml.count("[[datasets]]") == 2
         assert 'image_directory = "%s/data1"' % run in toml
 
-    def test_joint_poller_map_carries_the_second_group(self):
-        """The claim's second_* land in the TrainRequest; absent stays absent."""
+    def test_joint_poller_map_carries_every_extra_group(self):
+        """The claim's `identities` land in the TrainRequest; absent stays absent."""
         import inspect
         from wanly_worker.services.lora_trainer import poller as mod
         src = inspect.getsource(mod.Poller.tick)
-        assert "second_download_urls" in src
-        assert "second_identity" in src
+        assert 'row.get("identities")' in src
+        assert "identities=identities" in src
+
+
+class TestThreeGroups:
+    """#106: two solo sets AND a composition set -- frames containing both characters.
+    The composition set is the group that teaches the model the identities appear
+    together; solo sets alone produced a LoRA that held one face and dropped the other."""
+
+    def test_stage_writes_a_directory_and_caption_per_group(self, monkeypatch, tmp_path):
+        import asyncio
+        from wanly_worker.services.lora_trainer import pipeline
+        from wanly_worker.services.lora_trainer.jobs import Job
+
+        monkeypatch.setattr(pipeline.recipe, "RUNS_DIR", str(tmp_path))
+        job = Job(id="j1", character="payme", trigger="p@yton", version=1, steps=5250)
+        groups = [
+            {"images": [("a.jpg", b"x")], "caption": "p@yton, woman", "num_repeats": 10},
+            {"images": [("b.jpg", b"y")], "caption": "d@vid, man", "num_repeats": 10},
+            {"images": [("c.jpg", b"z")],
+             "caption": "p@yton, woman and d@vid, man", "num_repeats": 10},
+        ]
+        run = asyncio.run(pipeline.stage(job, groups))
+        assert (run / "data" / "sel_000.txt").read_text() == "p@yton, woman\n"
+        assert (run / "data1" / "sel_000.txt").read_text() == "d@vid, man\n"
+        assert (run / "data2" / "sel_000.txt").read_text() == \
+            "p@yton, woman and d@vid, man\n"
+        toml = (run / "dataset.toml").read_text()
+        assert toml.count("[[datasets]]") == 3
+        assert 'image_directory = "%s/data2"' % run in toml

--- a/wanly_worker/services/lora_trainer/app.py
+++ b/wanly_worker/services/lora_trainer/app.py
@@ -41,12 +41,13 @@ class TrainRequest(BaseModel):
     image_urls: list[str] = Field(default_factory=list)
     image_dir: str = ""
     caption: str | None = None
-    #: THE JOINT GROUP (#102). ABSENT means single-identity, which every run before this
-    #: is. One entry: {character, trigger, gender, image_urls, num_repeats} -- the second
-    #: dataset's URLs presigned by the API alongside group 0's, its caption resolved by
-    #: the same rule that made group 0's trigger carry. The claim builds it; a POST body
-    #: may also give it directly.
-    second_identity: dict | None = None
+    #: THE EXTRA GROUPS (#102, #106). ABSENT means single-identity, which every run before
+    #: this is. Each entry: {character, trigger, gender, caption, image_urls, num_repeats}
+    #: -- presigned by the API alongside group 0's. An IDENTITY group has a trigger and its
+    #: caption is "<trigger>, <gender>"; a COMPOSITION group (#106) has no trigger and its
+    #: caption names the people in its frames, which is what teaches the model they appear
+    #: together. The claim builds the list; a POST body may also give it directly.
+    identities: list[dict] = Field(default_factory=list)
     steps: int = Field(default=1200, ge=100, le=6000)
     config: dict = Field(default_factory=dict)
     remote_id: str = ""
@@ -190,34 +191,35 @@ async def _run(job: Job, req: TrainRequest, on_progress=None) -> None:
                 raise pipeline.PipelineError("no images to train on")
             job.images = len(images)
 
-            # ONE ENTRY PER IDENTITY GROUP. Group 0 is the job's own character; the joint
-            # group (#102) rides req.second_identity with its own URLs, caption and
-            # repeats. The stage call takes the list so per-group captions and dirs stay
-            # paired -- two separate stage calls would mean two dataset.toml writes, and
-            # the last one would win.
+            # ONE ENTRY PER GROUP. Group 0 is the job's own character; the extra groups
+            # (#102, #106) ride req.identities, each with its own URLs, caption and repeats.
+            # The stage call takes the whole list so per-group captions and dirs stay paired
+            # -- separate stage calls would mean separate dataset.toml writes, and the last
+            # one would win.
             groups = [{"images": images, "caption": req.caption,
                        "num_repeats": (req.config or {}).get("num_repeats")
                        or recipe.DEFAULTS["num_repeats"]}]
-            if req.second_identity:
-                si = req.second_identity
-                second_urls = si.get("image_urls") or []
-                if not second_urls and si.get("image_dir"):
-                    d = Path(si["image_dir"])
-                    second_images = [(f.name, f.read_bytes()) for f in sorted(d.iterdir())
-                                     if f.suffix.lower() in {".jpg", ".jpeg", ".png", ".webp"}]
+            for gi, g in enumerate(req.identities):
+                g_urls = g.get("image_urls") or []
+                if not g_urls and g.get("image_dir"):
+                    d = Path(g["image_dir"])
+                    g_images = [(f.name, f.read_bytes()) for f in sorted(d.iterdir())
+                                if f.suffix.lower() in {".jpg", ".jpeg", ".png", ".webp"}]
                 else:
-                    second_images = await _fetch(client, second_urls)
-                if not second_images:
-                    raise pipeline.PipelineError("no second-identity images to train on")
+                    g_images = await _fetch(client, g_urls)
+                if not g_images:
+                    raise pipeline.PipelineError(
+                        f"group {gi + 2} has no images to train on")
                 groups.append({
-                    "images": second_images,
-                    "caption": si.get("caption"),
-                    "num_repeats": si.get("num_repeats")
+                    "images": g_images,
+                    "caption": g.get("caption"),
+                    "num_repeats": g.get("num_repeats")
                     or recipe.DEFAULTS["num_repeats"],
                 })
-                job.images += len(second_images)
-                # The disk gate reads repeats x total images; a joint run's both groups
-                # count, and mixed repeats across groups would make the estimate a guess.
+                job.images += len(g_images)
+            if req.identities:
+                # The disk gate reads repeats x total images; every group counts, and mixed
+                # repeats across groups would make the estimate a guess.
                 job.effective_repeats = max(g["num_repeats"] for g in groups)
             pipeline.preflight(job)
             run = await pipeline.stage(job, groups)

--- a/wanly_worker/services/lora_trainer/poller.py
+++ b/wanly_worker/services/lora_trainer/poller.py
@@ -142,22 +142,26 @@ class Poller:
             return
 
         _log(f"claimed {row['character']} v{row['version']} ({len(row['download_urls'])} images)")
-        # THE JOINT GROUP (#102). second_* ride the claim response only for a joint run;
-        # ABSENT for every single-identity job, so this maps to None and the trainer's
-        # stage() writes the one-group shape it always has.
-        second = None
-        if row.get("second_download_urls"):
-            second = {
-                "character": row.get("config", {}).get("second_character"),
-                "image_urls": row["second_download_urls"],
-                "caption": row.get("second_caption"),
-                "num_repeats": row.get("second_num_repeats"),
+        # THE EXTRA GROUPS (#102, #106). `identities` rides the claim response only for a
+        # joint run; ABSENT for every single-identity job, so this maps to [] and the
+        # trainer's stage() writes the one-group shape it always has. Each entry keeps its
+        # own caption -- an identity group's is "<trigger>, <gender>", a composition group's
+        # names the people in its frames.
+        identities = [
+            {
+                "character": g.get("character"),
+                "trigger": g.get("trigger"),
+                "image_urls": g.get("download_urls") or [],
+                "caption": g.get("caption"),
+                "num_repeats": g.get("num_repeats"),
             }
+            for g in (row.get("identities") or [])
+        ]
         req = trainer_app.TrainRequest(
             character=row["character"], trigger=row["trigger"], version=row["version"],
             image_urls=row["download_urls"],
             caption=(row.get("config") or {}).get("caption"),
-            second_identity=second,
+            identities=identities,
             steps=(row.get("config") or {}).get("steps") or 1200,
             config=row.get("config") or {},
             remote_id=row["id"],


### PR DESCRIPTION
Trainer side of #106 (API: wanly-api#316, console: wanly-console PR).

## What

- `TrainRequest.second_identity` → **`identities` (a list)**.
- `_run` fetches every group's images and builds one `stage()` entry per group — a run can carry solo Payton, solo David, **and two-person frames** captioned with both triggers.
- `stage()`/`dataset_toml()` already took a list; this is the API delivering more groups and the poller mapping them. A composition group has no trigger and rides its own caption, so nothing here needs to know which kind a group is — **the caption is the contract**.

## Verification

- **357 passed.**
- New: three groups stage to `data/`, `data1/`, `data2/` with a three-entry toml and per-group captions; the poller maps the claim's `identities` list.