### PR TITLE
Raise the trainer's step ceiling to 30000

### DIFF
--- a/wanly_worker/services/lora_trainer/app.py
+++ b/wanly_worker/services/lora_trainer/app.py
@@ -48,7 +48,7 @@ class TrainRequest(BaseModel):
     #: caption names the people in its frames, which is what teaches the model they appear
     #: together. The claim builds the list; a POST body may also give it directly.
     identities: list[dict] = Field(default_factory=list)
-    steps: int = Field(default=1200, ge=100, le=6000)
+    steps: int = Field(default=1200, ge=100, le=30000)
     config: dict = Field(default_factory=dict)
     remote_id: str = ""
 


### PR DESCRIPTION
Matches wanly-api#317. A joint run at 8 epochs (8400 steps) exceeds the old `le=6000` on TrainRequest, and the claim constructs TrainRequest from the job's config.steps — so the poller would fail pydantic validation silently and the job would sit CLAIMED forever. The trainer trains whatever `max_train_steps` it is given; the cap was a sanity bound from single-set days.

Note: the 3090's worker.env now points at `:full` (main) instead of the stale `:next-full` — see #108.